### PR TITLE
fix: reduce statusline visual clutter

### DIFF
--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -300,8 +300,11 @@ func main() {
 	// Session name
 	sessionNameDisplay := statusline.FormatSessionNameDisplay(sessionName)
 
-	// Config info
-	configInfoDisplay := statusline.FormatConfigCountsDisplay(configInfo)
+	// Config info（加前導分隔符，與其他段落視覺一致）
+	configInfoDisplay := ""
+	if configInfo != "" {
+		configInfoDisplay = fmt.Sprintf("%s%s%s%s", sep.Divider, statusline.ColorDim, configInfo, statusline.ColorReset)
+	}
 
 	// 零值智慧隱藏：session time 為 "0m" 時不顯示
 	sessionDisplay := totalHours

--- a/pkg/git/branch.go
+++ b/pkg/git/branch.go
@@ -82,7 +82,7 @@ func GetBranch(dir string) string {
 		// 如果 git-dir 和 git-common-dir 不同，表示在 worktree 中
 		if absGitDir != absCommonDir {
 			icon = "🔀"
-			worktreeLabel = " (worktree)"
+			worktreeLabel = " (wt)"
 		}
 	}
 
@@ -97,13 +97,15 @@ func GetBranch(dir string) string {
 	return result
 }
 
-// FormatWorktreeBranch 格式化結構化 worktree 資料的分支顯示
+// FormatWorktreeBranch 格式化結構化 worktree 資料的分支顯示。
+// 當 branch 名稱已包含 worktree name（或反過來）時，用簡短 (wt) 標籤避免重複；
+// 否則顯示完整 (worktree: name)。
 func FormatWorktreeBranch(name, branch string) string {
 	if branch == "" {
 		return ""
 	}
-	label := " (worktree)"
-	if name != "" {
+	label := " (wt)"
+	if name != "" && !strings.Contains(branch, name) && !strings.Contains(name, branch) {
 		label = fmt.Sprintf(" (worktree: %s)", name)
 	}
 	return formatBranch("🔀", branch, label)

--- a/pkg/git/branch_test.go
+++ b/pkg/git/branch_test.go
@@ -105,12 +105,12 @@ func TestGetBranch_ActualWorktree(t *testing.T) {
 	// 獲取 worktree 的分支資訊
 	result := GetBranch(worktreePath)
 
-	// 驗證：實際的 worktree 應該使用 🔀 圖示並有 (worktree) 標籤
+	// 驗證：實際的 worktree 應該使用 🔀 圖示並有 (wt) 標籤
 	if !strings.Contains(result, "🔀") {
 		t.Errorf("Expected 🔀 icon for worktree, got: %s", result)
 	}
-	if !strings.Contains(result, "(worktree)") {
-		t.Errorf("Worktree should have (worktree) label, got: %s", result)
+	if !strings.Contains(result, "(wt)") {
+		t.Errorf("Worktree should have (wt) label, got: %s", result)
 	}
 	if !strings.Contains(result, "test-branch") {
 		t.Errorf("Expected branch name 'test-branch' in result, got: %s", result)
@@ -171,6 +171,94 @@ func TestGetBranch_VerifyGitCommands(t *testing.T) {
 	// 驗證：應該返回正確的分支名稱
 	if !strings.Contains(result, "feature-branch") {
 		t.Errorf("Expected branch name 'feature-branch' in result, got: %s", result)
+	}
+}
+
+func TestFormatWorktreeBranch(t *testing.T) {
+	tests := []struct {
+		name        string
+		wtName      string
+		branch      string
+		wantShort   bool   // true = expect (wt), false = expect (worktree: name)
+		wantContain string // branch name should appear in result
+	}{
+		{
+			name:        "name equals branch — smart-omit",
+			wtName:      "feature",
+			branch:      "feature",
+			wantShort:   true,
+			wantContain: "feature",
+		},
+		{
+			name:        "branch contains name — smart-omit",
+			wtName:      "fix",
+			branch:      "hotfix-deploy",
+			wantShort:   true,
+			wantContain: "hotfix-deploy",
+		},
+		{
+			name:        "name contains branch — smart-omit",
+			wtName:      "worktree-fix-story-gen-flow",
+			branch:      "fix-story-gen-flow",
+			wantShort:   true,
+			wantContain: "fix-story-gen-flow",
+		},
+		{
+			name:        "no overlap — full label",
+			wtName:      "hotfix",
+			branch:      "main",
+			wantShort:   false,
+			wantContain: "main",
+		},
+		{
+			name:        "empty name — always short",
+			wtName:      "",
+			branch:      "feature",
+			wantShort:   true,
+			wantContain: "feature",
+		},
+		{
+			name:        "empty branch — returns empty",
+			wtName:      "any",
+			branch:      "",
+			wantShort:   true, // irrelevant, result is ""
+			wantContain: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := FormatWorktreeBranch(tc.wtName, tc.branch)
+
+			if tc.branch == "" {
+				if result != "" {
+					t.Errorf("empty branch should return empty string, got %q", result)
+				}
+				return
+			}
+
+			if !strings.Contains(result, tc.wantContain) {
+				t.Errorf("expected result to contain %q, got %q", tc.wantContain, result)
+			}
+			if !strings.Contains(result, "🔀") {
+				t.Errorf("expected 🔀 icon, got %q", result)
+			}
+			if tc.wantShort {
+				if !strings.Contains(result, "(wt)") {
+					t.Errorf("expected short (wt) label, got %q", result)
+				}
+				if strings.Contains(result, "worktree:") {
+					t.Errorf("expected no full worktree label, got %q", result)
+				}
+			} else {
+				if strings.Contains(result, "(wt)") {
+					t.Errorf("expected full (worktree: name) label, got %q", result)
+				}
+				if !strings.Contains(result, "(worktree: "+tc.wtName+")") {
+					t.Errorf("expected (worktree: %s) in result, got %q", tc.wtName, result)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/statusline/builder.go
+++ b/pkg/statusline/builder.go
@@ -279,14 +279,6 @@ func FormatSessionNameDisplay(name string) string {
 	return fmt.Sprintf(" %s[%s]%s", ColorDim, name, ColorReset)
 }
 
-// FormatConfigCountsDisplay 格式化配置統計
-func FormatConfigCountsDisplay(countsStr string) string {
-	if countsStr == "" {
-		return ""
-	}
-	return fmt.Sprintf(" %s%s%s", ColorDim, countsStr, ColorReset)
-}
-
 // FormatAutocompactDisplay 格式化自動壓縮警告
 func FormatAutocompactDisplay(autocompactStr string) string {
 	if autocompactStr == "" {

--- a/pkg/statusline/metadata.go
+++ b/pkg/statusline/metadata.go
@@ -149,5 +149,5 @@ func FormatConfigCounts(counts *ConfigCounts) string {
 		return ""
 	}
 
-	return fmt.Sprintf("(%s)", strings.Join(parts, " "))
+	return fmt.Sprintf("(%s)", strings.Join(parts, " · "))
 }

--- a/pkg/statusline/truncate.go
+++ b/pkg/statusline/truncate.go
@@ -237,7 +237,7 @@ func WrapLine(segments []Segment, maxWidth int) string {
 	first := line2[0]
 	line2[0] = Segment{Content: stripLeadingDivider(first.Content), Priority: first.Priority}
 
-	const line2Prefix = " "
+	const line2Prefix = "↳ "
 	prefixWidth := VisibleWidth(line2Prefix)
 
 	// 計算第二行寬度

--- a/pkg/statusline/truncate_test.go
+++ b/pkg/statusline/truncate_test.go
@@ -127,8 +127,8 @@ func TestWrapLineWrapsToSecondLine(t *testing.T) {
 	if VisibleWidth(lines[0]) > 12 {
 		t.Errorf("line1 visible width %d exceeds maxWidth 12: %q", VisibleWidth(lines[0]), lines[0])
 	}
-	if !strings.HasPrefix(lines[1], " ") {
-		t.Errorf("line2 should start with single-space prefix, got %q", lines[1])
+	if !strings.HasPrefix(lines[1], "↳ ") {
+		t.Errorf("line2 should start with continuation prefix \"↳ \", got %q", lines[1])
 	}
 	if !strings.Contains(lines[1], "BBBB") {
 		t.Errorf("line2 should contain BBBB, got %q", lines[1])
@@ -145,12 +145,12 @@ func TestWrapLineStripsLeadingDivider(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %q", len(lines), got)
 	}
-	// " | " 應被去掉，改為前綴 " "
+	// " | " 應被去掉，改為前綴 "↳ "
 	if strings.HasPrefix(lines[1], " | ") {
 		t.Errorf("line2 should not start with \" | \", got %q", lines[1])
 	}
-	if !strings.HasPrefix(lines[1], " ") {
-		t.Errorf("line2 should start with single-space prefix, got %q", lines[1])
+	if !strings.HasPrefix(lines[1], "↳ ") {
+		t.Errorf("line2 should start with continuation prefix \"↳ \", got %q", lines[1])
 	}
 	if !strings.Contains(lines[1], "BBBB") {
 		t.Errorf("line2 should still contain BBBB, got %q", lines[1])
@@ -161,7 +161,7 @@ func TestWrapLineFallbackTruncate(t *testing.T) {
 	// maxWidth=10：
 	// line1: "AAAA"(4)，" | BBBBB"(8) 4+8=12>10 → 移到 line2
 	// line2: [" | BBBBB"(P3), " | CCCCC"(P5), " | DDDDD"(P9)]
-	// line2 strip 後: "BBBBB"(5) + " | CCCCC"(8) + " | DDDDD"(8) = 21+前綴1 = 22 > 10
+	// line2 strip 後: "BBBBB"(5) + " | CCCCC"(8) + " | DDDDD"(8) = 21+前綴2("↳ ") = 23 > 10
 	// → 觸發 TruncateLine，Priority 9（DDDDD）被丟棄
 	segs := []Segment{
 		{Content: "AAAA", Priority: 1},     // 4
@@ -206,7 +206,7 @@ func TestWrapLineSingleOversizedSegment(t *testing.T) {
 
 func TestWrapLineWithAnsiColors(t *testing.T) {
 	// 模擬真實段落：model(21) + " | ⚡ main"(9) = 30 > 25，git 換到第二行
-	// git 以 " | " 開頭，觸發 stripLeadingDivider，line2 = " ⚡ main"（單空格前綴）
+	// git 以 " | " 開頭，觸發 stripLeadingDivider，line2 = "↳ ⚡ main"（↳ 續行前綴）
 	model := "\033[0m[💛 Opus 4.6] 📂 proj\033[0m" // visible: 21
 	git := " | ⚡ main"                           // visible: 9, starts with " | "
 	segs := []Segment{
@@ -221,12 +221,9 @@ func TestWrapLineWithAnsiColors(t *testing.T) {
 	if VisibleWidth(lines[0]) > 25 {
 		t.Errorf("line1 visible width %d exceeds maxWidth 25", VisibleWidth(lines[0]))
 	}
-	// stripLeadingDivider 去掉 " | "，line2Prefix 加 " "，結果為 " ⚡ main"（精確單空格）
-	if !strings.HasPrefix(lines[1], " ") {
-		t.Errorf("line2 should start with single-space prefix, got %q", lines[1])
-	}
-	if strings.HasPrefix(lines[1], "  ") {
-		t.Errorf("line2 should not start with double space (divider not stripped), got %q", lines[1])
+	// stripLeadingDivider 去掉 " | "，line2Prefix 加 "↳ "，結果為 "↳ ⚡ main"
+	if !strings.HasPrefix(lines[1], "↳ ") {
+		t.Errorf("line2 should start with continuation prefix \"↳ \", got %q", lines[1])
 	}
 	if !strings.Contains(lines[1], "main") {
 		t.Errorf("line2 should contain git branch, got %q", lines[1])


### PR DESCRIPTION
## Summary

- **Smarter worktree labels**: `FormatWorktreeBranch` now shows `(wt)` when the branch name already contains the worktree name (e.g. `worktree-fix-story` → branch `fix-story` → `(wt)`). Only shows full `(worktree: name)` when names are completely unrelated
- **Shorter generic label**: `GetBranch` changed from `(worktree)` to `(wt)`
- **Config info separator**: Changed from space to ` · ` (e.g. `(1md · 4hook · 1mcp)`)
- **Config info divider**: Added `sep.Divider` prefix so it visually separates from the session segment
- **Wrap second-line prefix**: Changed from bare space `' '` to `↳ ` continuation marker
- **Dead code removed**: `FormatConfigCountsDisplay` was no longer called

## Motivation

Statusline was hard to read when multiple segments appeared on the same line — especially worktree sessions where the branch name and worktree name were nearly identical, doubling the length for no information gain.

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Added `TestFormatWorktreeBranch` with 6 table-driven cases covering: exact match, branch⊇name, name⊇branch, no overlap (full label), empty name, empty branch
- [x] Pre-commit hooks (fmt + lint + test) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)