### PR TITLE
fix: split context segment so percentage survives narrow terminals

### DIFF
--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -60,13 +60,13 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			var contextUsage string
+			var ctxData *context.ContextData
 			if lines != nil {
-				contextUsage = context.AnalyzeFromLines(lines, maxTokens)
+				ctxData = context.AnalyzeDetailedFromLines(lines, maxTokens)
 			} else {
-				contextUsage = context.Analyze(input.TranscriptPath, maxTokens)
+				ctxData = context.AnalyzeDetailed(input.TranscriptPath, maxTokens)
 			}
-			results <- statusline.Result{Type: "context", Data: contextUsage}
+			results <- statusline.Result{Type: "context", Data: ctxData}
 		}()
 	}
 
@@ -222,19 +222,21 @@ func main() {
 
 	// Phase 4: 收集結果
 	var (
-		gitBranch    string
-		gitStatusStr string
-		totalHours   string
-		contextUsage string
-		userMessage  string
-		toolsStr     string
-		agentsStr    string
-		todoStr      string
-		speedStr     string
-		autocompact  string
-		sessionName  string
-		apiLimits    string
-		configInfo   string
+		gitBranch     string
+		gitStatusStr  string
+		totalHours    string
+		contextBar    string
+		contextInfo   string
+		contextTokens int
+		userMessage   string
+		toolsStr      string
+		agentsStr     string
+		todoStr       string
+		speedStr      string
+		autocompact   string
+		sessionName   string
+		apiLimits     string
+		configInfo    string
 	)
 
 	for result := range results {
@@ -246,7 +248,11 @@ func main() {
 		case "hours":
 			totalHours = result.Data.(string)
 		case "context":
-			contextUsage = result.Data.(string)
+			if ctxData, ok := result.Data.(*context.ContextData); ok && ctxData != nil {
+				contextBar = ctxData.Bar
+				contextInfo = ctxData.Info
+				contextTokens = ctxData.Tokens
+			}
 		case "message":
 			userMessage = result.Data.(string)
 		case "tools":
@@ -322,11 +328,14 @@ func main() {
 	}
 
 	// Line 1: 主要狀態列（段落優先級截斷）
+	// contextBar（進度條，priority 4）可被捨棄；
+	// contextInfo（百分比+token，priority 2）幾乎不被捨棄，確保數字資訊始終可見。
 	line1Segments := []statusline.Segment{
 		{Content: fmt.Sprintf("%s[%s] 📂 %s", statusline.ColorReset, modelDisplay, projectName), Priority: 1},
 		{Content: sessionNameDisplay, Priority: 10},
 		{Content: gitDisplay, Priority: 3},
-		{Content: contextUsage, Priority: 4},
+		{Content: contextBar, Priority: 4},
+		{Content: contextInfo, Priority: 2},
 		{Content: speedDisplay, Priority: 7},
 		{Content: autocompactDisplay, Priority: 8},
 		{Content: linesDisplay, Priority: 9},
@@ -334,6 +343,21 @@ func main() {
 		{Content: costDisplay, Priority: 6},
 		{Content: configInfoDisplay, Priority: 11},
 		{Content: statusline.ColorReset, Priority: 0},
+	}
+	if os.Getenv("STATUSLINE_DEBUG") == "1" {
+		fmt.Fprintf(os.Stderr, "[debug] termWidth=%d overflowMode=%q tokens=%d\n",
+			termWidth, cfg.OverflowMode, contextTokens)
+		total := 0
+		for _, seg := range line1Segments {
+			if seg.Content == "" {
+				continue
+			}
+			w := statusline.VisibleWidth(seg.Content)
+			total += w
+			fmt.Fprintf(os.Stderr, "[debug]   priority=%d width=%d content=%q\n",
+				seg.Priority, w, seg.Content)
+		}
+		fmt.Fprintf(os.Stderr, "[debug] total visible width=%d\n", total)
 	}
 	fmt.Println(formatSegments(line1Segments, termWidth, cfg.OverflowMode))
 

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -48,7 +48,10 @@ func main() {
 	}
 
 	// Phase 2: 讀取 transcript（一次 I/O）
-	lines, _ := transcript.ReadTail(input.TranscriptPath, 200)
+	lines, err := transcript.ReadTail(input.TranscriptPath, 200)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "statusline: failed to read transcript %q: %v\n", input.TranscriptPath, err)
+	}
 
 	// Phase 3: 並行處理所有資料收集
 	results := make(chan statusline.Result, 12)
@@ -248,11 +251,18 @@ func main() {
 		case "hours":
 			totalHours = result.Data.(string)
 		case "context":
-			if ctxData, ok := result.Data.(*context.ContextData); ok && ctxData != nil {
-				contextBar = ctxData.Bar
-				contextInfo = ctxData.Info
-				contextTokens = ctxData.Tokens
+			ctxData, ok := result.Data.(*context.ContextData)
+			if !ok {
+				fmt.Fprintf(os.Stderr, "statusline: unexpected type for context result: %T\n", result.Data)
+				break
 			}
+			if ctxData == nil {
+				fmt.Fprintf(os.Stderr, "statusline: context result is nil, context section will be empty\n")
+				break
+			}
+			contextBar = ctxData.Bar
+			contextInfo = ctxData.Info
+			contextTokens = ctxData.Tokens
 		case "message":
 			userMessage = result.Data.(string)
 		case "tools":

--- a/pkg/context/tracker.go
+++ b/pkg/context/tracker.go
@@ -83,6 +83,9 @@ func AnalyzeDetailed(transcriptPath string, maxTokens int) *ContextData {
 // bar 為含前導分隔符的進度條（如 " | ░░░░░░░░░░"）；
 // info 為百分比和 token 數（如 " 74% 148k"，帶顏色）。
 func FormatContextParts(contextLength, maxTokens int) (bar string, info string) {
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
 	percentage := int(float64(contextLength) * 100.0 / float64(maxTokens))
 	if percentage > 100 {
 		percentage = 100

--- a/pkg/context/tracker.go
+++ b/pkg/context/tracker.go
@@ -21,7 +21,9 @@ const DefaultMaxTokens = 200000
 
 // ContextData 包含 context 分析的完整結果
 type ContextData struct {
-	Formatted  string // 格式化的進度條字串
+	Formatted  string // 格式化的進度條字串（向後相容）
+	Bar        string // 僅進度條部分（含前導分隔符，如 " | ░░░░░░░░░░"）
+	Info       string // 百分比 + token 數（如 " 74% 148k"）
 	Percentage int    // 百分比數值
 	Tokens     int    // token 數量
 }
@@ -61,19 +63,26 @@ func AnalyzeDetailedFromLines(lines []transcript.Line, maxTokens int) *ContextDa
 	}
 
 	contextLength := calculateUsageFromLines(lines)
-	percentage := int(float64(contextLength) * 100.0 / float64(maxTokens))
-	if percentage > 100 {
-		percentage = 100
-	}
-
-	return &ContextData{
-		Formatted:  formatContext(contextLength, maxTokens),
-		Percentage: percentage,
-		Tokens:     contextLength,
-	}
+	return buildContextData(contextLength, maxTokens)
 }
 
-func formatContext(contextLength, maxTokens int) string {
+// AnalyzeDetailed 返回詳細的 context 資料（從檔案路徑讀取）
+func AnalyzeDetailed(transcriptPath string, maxTokens int) *ContextData {
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+
+	var contextLength int
+	if transcriptPath != "" {
+		contextLength = calculateUsage(transcriptPath)
+	}
+	return buildContextData(contextLength, maxTokens)
+}
+
+// FormatContextParts 將 context 分為進度條和資訊兩部分，讓呼叫端分別設定截斷優先級。
+// bar 為含前導分隔符的進度條（如 " | ░░░░░░░░░░"）；
+// info 為百分比和 token 數（如 " 74% 148k"，帶顏色）。
+func FormatContextParts(contextLength, maxTokens int) (bar string, info string) {
 	percentage := int(float64(contextLength) * 100.0 / float64(maxTokens))
 	if percentage > 100 {
 		percentage = 100
@@ -82,13 +91,37 @@ func formatContext(contextLength, maxTokens int) string {
 	progressBar := generateProgressBar(percentage)
 	formattedNum := formatNumber(contextLength)
 
+	bar = " | " + progressBar
+
 	if RenderMode == terminal.ModeASCII {
-		return fmt.Sprintf(" | %s %d%% %s", progressBar, percentage, formattedNum)
+		info = fmt.Sprintf(" %d%% %s", percentage, formattedNum)
+	} else {
+		color := getColor(percentage)
+		info = fmt.Sprintf(" %s%d%% %s%s", color, percentage, formattedNum, statusline.ColorReset)
+	}
+	return bar, info
+}
+
+// buildContextData 從 contextLength 和 maxTokens 建立完整的 ContextData。
+func buildContextData(contextLength, maxTokens int) *ContextData {
+	percentage := int(float64(contextLength) * 100.0 / float64(maxTokens))
+	if percentage > 100 {
+		percentage = 100
 	}
 
-	color := getColor(percentage)
-	return fmt.Sprintf(" | %s %s%d%% %s%s",
-		progressBar, color, percentage, formattedNum, statusline.ColorReset)
+	bar, info := FormatContextParts(contextLength, maxTokens)
+	return &ContextData{
+		Formatted:  bar + info,
+		Bar:        bar,
+		Info:       info,
+		Percentage: percentage,
+		Tokens:     contextLength,
+	}
+}
+
+func formatContext(contextLength, maxTokens int) string {
+	bar, info := FormatContextParts(contextLength, maxTokens)
+	return bar + info
 }
 
 // calculateUsageFromLines 從共享 transcript 行計算 Context 使用量

--- a/pkg/context/tracker_test.go
+++ b/pkg/context/tracker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/howie/claude-code-omystatusline/pkg/statusline"
+	"github.com/howie/claude-code-omystatusline/pkg/transcript"
 )
 
 func TestFormatNumber(t *testing.T) {
@@ -74,6 +75,70 @@ func TestAnalyzeEmptyPath(t *testing.T) {
 	result := Analyze("", 0)
 	if !strings.Contains(result, "0%") {
 		t.Fatalf("Analyze with empty path should show 0%%, got %q", result)
+	}
+}
+
+func TestFormatContextParts(t *testing.T) {
+	tests := []struct {
+		name          string
+		contextLength int
+		maxTokens     int
+		wantBarPrefix string // bar 應以 " | " 開頭
+		wantInfo      string // info 應包含此字串
+	}{
+		{"zero tokens", 0, 200000, " | ", "0%"},
+		{"50 percent", 100000, 200000, " | ", "50%"},
+		{"100 percent", 200000, 200000, " | ", "100%"},
+		{"token count", 148000, 200000, " | ", "148k"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bar, info := FormatContextParts(tt.contextLength, tt.maxTokens)
+			if !strings.HasPrefix(bar, tt.wantBarPrefix) {
+				t.Errorf("bar should start with %q, got %q", tt.wantBarPrefix, bar)
+			}
+			if !strings.Contains(info, tt.wantInfo) {
+				t.Errorf("info should contain %q, got %q", tt.wantInfo, info)
+			}
+			// bar 不應包含百分比，info 不應包含進度條字元
+			if strings.Contains(bar, "%") {
+				t.Errorf("bar should not contain percentage, got %q", bar)
+			}
+		})
+	}
+}
+
+func TestAnalyzeDetailedFromLines(t *testing.T) {
+	lines := []transcript.Line{
+		{Raw: `{"message":{"usage":{"input_tokens":148027}},"isSidechain":false}`, Parsed: map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{"input_tokens": float64(148027)},
+			},
+			"isSidechain": false,
+		}},
+	}
+
+	data := AnalyzeDetailedFromLines(lines, 200000)
+	if data == nil {
+		t.Fatal("expected non-nil ContextData")
+	}
+	if data.Tokens != 148027 {
+		t.Errorf("expected Tokens=148027, got %d", data.Tokens)
+	}
+	if data.Percentage != 74 {
+		t.Errorf("expected Percentage=74, got %d", data.Percentage)
+	}
+	if data.Bar == "" {
+		t.Error("Bar should not be empty")
+	}
+	if data.Info == "" {
+		t.Error("Info should not be empty")
+	}
+	// Formatted should be Bar + Info
+	if data.Formatted != data.Bar+data.Info {
+		t.Errorf("Formatted should equal Bar+Info, got Formatted=%q, Bar+Info=%q",
+			data.Formatted, data.Bar+data.Info)
 	}
 }
 

--- a/pkg/statusline/truncate_test.go
+++ b/pkg/statusline/truncate_test.go
@@ -263,6 +263,42 @@ func TestStripLeadingDivider(t *testing.T) {
 	}
 }
 
+func TestTruncateLineSplitContextKeepsInfo(t *testing.T) {
+	// 模擬長分支名情境：終端寬度不足時，進度條（priority 4）被捨棄，
+	// 但百分比資訊（priority 2）因優先級高而保留。
+	model := "[Sonnet] 📂 backend"                            // visible: 19
+	git := " 🔀 worktree-tts-performance-improvement (wt)*!6" // visible: 49
+	contextBar := " | ░░░░░░░░░░"                            // visible: 14
+	contextInfo := " 74% 148k"                               // visible: 9
+	session := " | 2h10m"                                    // visible: 8
+
+	segs := []Segment{
+		{Content: model, Priority: 1},
+		{Content: git, Priority: 3},
+		{Content: contextBar, Priority: 4},
+		{Content: contextInfo, Priority: 2},
+		{Content: session, Priority: 5},
+	}
+
+	// 寬終端：全部顯示
+	full := TruncateLine(segs, 200)
+	if !strings.Contains(full, "74%") {
+		t.Errorf("full width should contain context info, got %q", full)
+	}
+	if !strings.Contains(full, "░") {
+		t.Errorf("full width should contain progress bar, got %q", full)
+	}
+
+	// 窄終端（~80）：session 和 contextBar 被捨棄，contextInfo 仍保留
+	narrow := TruncateLine(segs, 82)
+	if !strings.Contains(narrow, "74%") {
+		t.Errorf("narrow width should still show percentage, got %q", narrow)
+	}
+	if strings.Contains(narrow, "2h10m") {
+		t.Errorf("narrow width should drop session (lower priority), got %q", narrow)
+	}
+}
+
 func TestTruncateLineWithAnsiColors(t *testing.T) {
 	// Simulate real status line segments with ANSI codes
 	model := "\033[0m[💛 Opus 4.6] 📂 project\033[0m" // visible: ~22 chars


### PR DESCRIPTION
## Summary

- **根因**：token 進度條（`░░░░░░░░░░`）和百分比（`74% 148k`）被綁在同一個 Segment（priority 4），終端太窄時整個 segment 被 `TruncateLine` 捨棄，導致百分比消失
- **修復**：拆成兩個不同優先級的 segment — 進度條（priority 4，可被捨棄）和百分比+token（priority 2，幾乎不被捨棄）
- **新增**：`STATUSLINE_DEBUG=1` 環境變數，輸出各 segment 寬度和 token 值到 stderr，方便未來 debug

## Changes

- `pkg/context/tracker.go`: 新增 `FormatContextParts()`、`AnalyzeDetailed()`、`buildContextData()` 函式；`ContextData` struct 加入 `Bar`/`Info` 欄位
- `cmd/statusline/main.go`: context goroutine 改用 `AnalyzeDetailedFromLines`/`AnalyzeDetailed`；segment 拆為 `contextBar`（P4）和 `contextInfo`（P2）；新增 debug 模式
- `pkg/context/tracker_test.go`: 新增 `TestFormatContextParts`、`TestAnalyzeDetailedFromLines`
- `pkg/statusline/truncate_test.go`: 新增 `TestTruncateLineSplitContextKeepsInfo`（長分支名 + 窄終端情境）

## Test plan

- [x] `go test ./...` 全部通過
- [x] pre-commit / pre-push hooks 通過
- [x] 實測 `STATUSLINE_DEBUG=1` 確認 `tokens=148027`、priority 2/4 segment 正確分離
- [ ] 在有問題的 session 裡確認百分比現在顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)