### PR TITLE
Add cache hit rate tracking and display to status line

### DIFF
--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/howie/claude-code-omystatusline/pkg/agents"
 	"github.com/howie/claude-code-omystatusline/pkg/apilimits"
+	"github.com/howie/claude-code-omystatusline/pkg/cache"
 	"github.com/howie/claude-code-omystatusline/pkg/config"
 	"github.com/howie/claude-code-omystatusline/pkg/context"
 	"github.com/howie/claude-code-omystatusline/pkg/git"
@@ -54,7 +55,7 @@ func main() {
 	}
 
 	// Phase 3: 並行處理所有資料收集
-	results := make(chan statusline.Result, 12)
+	results := make(chan statusline.Result, 13)
 	var wg sync.WaitGroup
 
 	// --- Transcript-based goroutines ---
@@ -152,6 +153,19 @@ func main() {
 		}()
 	}
 
+	if cfg.Sections.CacheHitRate {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if lines == nil {
+				results <- statusline.Result{Type: "cache", Data: (*cache.CacheInfo)(nil)}
+				return
+			}
+			cacheInfo := cache.Calculate(lines)
+			results <- statusline.Result{Type: "cache", Data: cacheInfo}
+		}()
+	}
+
 	if cfg.Sections.SessionName {
 		wg.Add(1)
 		go func() {
@@ -237,6 +251,8 @@ func main() {
 		todoStr       string
 		speedStr      string
 		autocompact   string
+		cacheStr      string
+		cacheRate     int
 		sessionName   string
 		apiLimits     string
 		configInfo    string
@@ -275,6 +291,12 @@ func main() {
 			speedStr = result.Data.(string)
 		case "autocompact":
 			autocompact = result.Data.(string)
+		case "cache":
+			cacheInfo, ok := result.Data.(*cache.CacheInfo)
+			if ok && cacheInfo != nil {
+				cacheStr = cache.Format(cacheInfo)
+				cacheRate = cacheInfo.HitRate
+			}
 		case "session_name":
 			sessionName = result.Data.(string)
 		case "api_limits":
@@ -313,6 +335,9 @@ func main() {
 	// Autocompact 附加在 context 後
 	autocompactDisplay := statusline.FormatAutocompactDisplay(autocompact)
 
+	// Cache hit rate
+	cacheDisplay := statusline.FormatCacheDisplay(cacheStr, cacheRate)
+
 	// Session name
 	sessionNameDisplay := statusline.FormatSessionNameDisplay(sessionName)
 
@@ -348,6 +373,7 @@ func main() {
 		{Content: contextInfo, Priority: 2},
 		{Content: speedDisplay, Priority: 7},
 		{Content: autocompactDisplay, Priority: 8},
+		{Content: cacheDisplay, Priority: 12},
 		{Content: linesDisplay, Priority: 9},
 		{Content: sessionWithDivider, Priority: 5},
 		{Content: costDisplay, Priority: 6},

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	// Phase 3: 並行處理所有資料收集
-	results := make(chan statusline.Result, 13)
+	results := make(chan statusline.Result, 14)
 	var wg sync.WaitGroup
 
 	// --- Transcript-based goroutines ---

--- a/pkg/cache/tracker.go
+++ b/pkg/cache/tracker.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/howie/claude-code-omystatusline/pkg/transcript"
+)
+
+// CacheInfo 代表快取命中率資訊
+type CacheInfo struct {
+	HitRate    int // 0-100 百分比
+	CacheRead  int // cache_read_input_tokens
+	TotalInput int // 三種 token 的總和
+}
+
+// Calculate 從 transcript 行計算快取命中率
+func Calculate(lines []transcript.Line) *CacheInfo {
+	for i := len(lines) - 1; i >= 0; i-- {
+		l := lines[i]
+		if l.Parsed == nil {
+			continue
+		}
+
+		if isSide, ok := l.Parsed["isSidechain"].(bool); ok && isSide {
+			continue
+		}
+
+		msg, ok := l.Parsed["message"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		usage, ok := msg["usage"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		var inputTokens, cacheRead, cacheCreation float64
+
+		if v, ok := usage["input_tokens"].(float64); ok {
+			inputTokens = v
+		}
+		if v, ok := usage["cache_read_input_tokens"].(float64); ok {
+			cacheRead = v
+		}
+		if v, ok := usage["cache_creation_input_tokens"].(float64); ok {
+			cacheCreation = v
+		}
+
+		total := inputTokens + cacheRead + cacheCreation
+		if total <= 0 {
+			continue
+		}
+
+		hitRate := int(cacheRead * 100.0 / total)
+		return &CacheInfo{
+			HitRate:    hitRate,
+			CacheRead:  int(cacheRead),
+			TotalInput: int(total),
+		}
+	}
+
+	return nil
+}
+
+// Format 格式化快取命中率顯示
+func Format(info *CacheInfo) string {
+	if info == nil {
+		return ""
+	}
+	return fmt.Sprintf("Cache %d%%", info.HitRate)
+}

--- a/pkg/cache/tracker_test.go
+++ b/pkg/cache/tracker_test.go
@@ -1,0 +1,190 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/howie/claude-code-omystatusline/pkg/transcript"
+)
+
+func makeLine(raw string, parsed map[string]interface{}) transcript.Line {
+	return transcript.Line{Raw: raw, Parsed: parsed}
+}
+
+func TestCalculateNormal(t *testing.T) {
+	lines := []transcript.Line{
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{
+					"input_tokens":                float64(20),
+					"cache_read_input_tokens":     float64(80),
+					"cache_creation_input_tokens": float64(0),
+				},
+			},
+			"isSidechain": false,
+		}),
+	}
+
+	info := Calculate(lines)
+	if info == nil {
+		t.Fatal("expected non-nil CacheInfo")
+	}
+	if info.HitRate != 80 {
+		t.Errorf("expected HitRate=80, got %d", info.HitRate)
+	}
+	if info.CacheRead != 80 {
+		t.Errorf("expected CacheRead=80, got %d", info.CacheRead)
+	}
+	if info.TotalInput != 100 {
+		t.Errorf("expected TotalInput=100, got %d", info.TotalInput)
+	}
+}
+
+func TestCalculateSkipsSidechain(t *testing.T) {
+	lines := []transcript.Line{
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{
+					"input_tokens":                float64(50),
+					"cache_read_input_tokens":     float64(50),
+					"cache_creation_input_tokens": float64(0),
+				},
+			},
+			"isSidechain": false,
+		}),
+		// 最後一行是 sidechain，應被跳過
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{
+					"input_tokens":                float64(100),
+					"cache_read_input_tokens":     float64(0),
+					"cache_creation_input_tokens": float64(0),
+				},
+			},
+			"isSidechain": true,
+		}),
+	}
+
+	info := Calculate(lines)
+	if info == nil {
+		t.Fatal("expected non-nil CacheInfo")
+	}
+	// 應該取得第一行（非 sidechain）的資料
+	if info.HitRate != 50 {
+		t.Errorf("expected HitRate=50, got %d", info.HitRate)
+	}
+}
+
+func TestCalculateNoUsage(t *testing.T) {
+	lines := []transcript.Line{
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"role": "user",
+			},
+		}),
+		makeLine("", nil),
+	}
+
+	info := Calculate(lines)
+	if info != nil {
+		t.Errorf("expected nil CacheInfo, got %+v", info)
+	}
+}
+
+func TestCalculateZeroTotal(t *testing.T) {
+	lines := []transcript.Line{
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{
+					"input_tokens":                float64(0),
+					"cache_read_input_tokens":     float64(0),
+					"cache_creation_input_tokens": float64(0),
+				},
+			},
+			"isSidechain": false,
+		}),
+	}
+
+	info := Calculate(lines)
+	if info != nil {
+		t.Errorf("expected nil CacheInfo for zero total, got %+v", info)
+	}
+}
+
+func TestCalculateAllCacheRead(t *testing.T) {
+	lines := []transcript.Line{
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{
+					"input_tokens":                float64(0),
+					"cache_read_input_tokens":     float64(100),
+					"cache_creation_input_tokens": float64(0),
+				},
+			},
+			"isSidechain": false,
+		}),
+	}
+
+	info := Calculate(lines)
+	if info == nil {
+		t.Fatal("expected non-nil CacheInfo")
+	}
+	if info.HitRate != 100 {
+		t.Errorf("expected HitRate=100, got %d", info.HitRate)
+	}
+}
+
+func TestCalculateNoCacheRead(t *testing.T) {
+	lines := []transcript.Line{
+		makeLine("", map[string]interface{}{
+			"message": map[string]interface{}{
+				"usage": map[string]interface{}{
+					"input_tokens":                float64(100),
+					"cache_read_input_tokens":     float64(0),
+					"cache_creation_input_tokens": float64(50),
+				},
+			},
+			"isSidechain": false,
+		}),
+	}
+
+	info := Calculate(lines)
+	if info == nil {
+		t.Fatal("expected non-nil CacheInfo")
+	}
+	if info.HitRate != 0 {
+		t.Errorf("expected HitRate=0, got %d", info.HitRate)
+	}
+}
+
+func TestCalculateEmptyLines(t *testing.T) {
+	info := Calculate(nil)
+	if info != nil {
+		t.Errorf("expected nil for nil lines, got %+v", info)
+	}
+
+	info = Calculate([]transcript.Line{})
+	if info != nil {
+		t.Errorf("expected nil for empty lines, got %+v", info)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	if got := Format(nil); got != "" {
+		t.Errorf("Format(nil) = %q, want empty", got)
+	}
+
+	info := &CacheInfo{HitRate: 85}
+	if got := Format(info); got != "Cache 85%" {
+		t.Errorf("Format({HitRate:85}) = %q, want %q", got, "Cache 85%")
+	}
+
+	info = &CacheInfo{HitRate: 0}
+	if got := Format(info); got != "Cache 0%" {
+		t.Errorf("Format({HitRate:0}) = %q, want %q", got, "Cache 0%")
+	}
+
+	info = &CacheInfo{HitRate: 100}
+	if got := Format(info); got != "Cache 100%" {
+		t.Errorf("Format({HitRate:100}) = %q, want %q", got, "Cache 100%")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,21 +53,22 @@ func (c *Config) GetSeparator() SeparatorStyle {
 
 // SectionVisibility 各區段的可見性設定
 type SectionVisibility struct {
-	Model       bool `json:"model"`
-	Git         bool `json:"git"`
-	GitStatus   bool `json:"git_status"`
-	Context     bool `json:"context"`
-	Session     bool `json:"session"`
-	Cost        bool `json:"cost"`
-	Tools       bool `json:"tools"`
-	Agents      bool `json:"agents"`
-	Todo        bool `json:"todo"`
-	APILimits   bool `json:"api_limits"`
-	Speed       bool `json:"speed"`
-	SessionName bool `json:"session_name"`
-	ConfigInfo  bool `json:"config_info"`
-	Autocompact bool `json:"autocompact"`
-	UserMessage bool `json:"user_message"`
+	Model        bool `json:"model"`
+	Git          bool `json:"git"`
+	GitStatus    bool `json:"git_status"`
+	Context      bool `json:"context"`
+	Session      bool `json:"session"`
+	Cost         bool `json:"cost"`
+	Tools        bool `json:"tools"`
+	Agents       bool `json:"agents"`
+	Todo         bool `json:"todo"`
+	APILimits    bool `json:"api_limits"`
+	Speed        bool `json:"speed"`
+	SessionName  bool `json:"session_name"`
+	ConfigInfo   bool `json:"config_info"`
+	Autocompact  bool `json:"autocompact"`
+	CacheHitRate bool `json:"cache_hit_rate"`
+	UserMessage  bool `json:"user_message"`
 }
 
 // DefaultConfig 返回預設配置（所有區段可見）
@@ -76,21 +77,22 @@ func DefaultConfig() *Config {
 		DisplayMode:  "expanded",
 		OverflowMode: "wrap",
 		Sections: SectionVisibility{
-			Model:       true,
-			Git:         true,
-			GitStatus:   true,
-			Context:     true,
-			Session:     true,
-			Cost:        true,
-			Tools:       true,
-			Agents:      true,
-			Todo:        true,
-			APILimits:   true,
-			Speed:       true,
-			SessionName: true,
-			ConfigInfo:  true,
-			Autocompact: true,
-			UserMessage: true,
+			Model:        true,
+			Git:          true,
+			GitStatus:    true,
+			Context:      true,
+			Session:      true,
+			Cost:         true,
+			Tools:        true,
+			Agents:       true,
+			Todo:         true,
+			APILimits:    true,
+			Speed:        true,
+			SessionName:  true,
+			ConfigInfo:   true,
+			Autocompact:  true,
+			CacheHitRate: true,
+			UserMessage:  true,
 		},
 	}
 }

--- a/pkg/statusline/builder.go
+++ b/pkg/statusline/builder.go
@@ -310,6 +310,24 @@ func FormatLinesChanged(added, removed int) string {
 	return " " + strings.Join(parts, "/")
 }
 
+// FormatCacheDisplay 格式化快取命中率顯示，依命中率著色
+// hitRate >= 80: 綠色, 50-79: 黃色, < 50: 紅色
+func FormatCacheDisplay(cacheStr string, hitRate int) string {
+	if cacheStr == "" {
+		return ""
+	}
+	var color string
+	switch {
+	case hitRate >= 80:
+		color = ColorGreen
+	case hitRate >= 50:
+		color = ColorYellow
+	default:
+		color = ColorRed
+	}
+	return fmt.Sprintf(" %s%s%s", color, cacheStr, ColorReset)
+}
+
 // FormatCostColored 格式化 cost 顯示，依金額著色
 // <$5 預設色，≥$5 黃色，≥$10 紅色
 // sep 為分隔符（例如 " | "）

--- a/pkg/statusline/builder_test.go
+++ b/pkg/statusline/builder_test.go
@@ -131,6 +131,45 @@ func TestFormatLinesChanged(t *testing.T) {
 	}
 }
 
+func TestFormatCacheDisplay(t *testing.T) {
+	tests := []struct {
+		name      string
+		cacheStr  string
+		hitRate   int
+		wantEmpty bool
+		wantColor string
+	}{
+		{"empty string", "", 0, true, ""},
+		{"high hit rate", "Cache 85%", 85, false, ColorGreen},
+		{"boundary green", "Cache 80%", 80, false, ColorGreen},
+		{"medium hit rate", "Cache 65%", 65, false, ColorYellow},
+		{"boundary yellow", "Cache 50%", 50, false, ColorYellow},
+		{"low hit rate", "Cache 30%", 30, false, ColorRed},
+		{"zero hit rate", "Cache 0%", 0, false, ColorRed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatCacheDisplay(tt.cacheStr, tt.hitRate)
+			if tt.wantEmpty {
+				if result != "" {
+					t.Fatalf("expected empty for %q, got %q", tt.cacheStr, result)
+				}
+				return
+			}
+			if !strings.Contains(result, tt.wantColor) {
+				t.Fatalf("expected color %q for hitRate %d, got %q", tt.wantColor, tt.hitRate, result)
+			}
+			if !strings.Contains(result, tt.cacheStr) {
+				t.Fatalf("expected %q in result, got %q", tt.cacheStr, result)
+			}
+			if !strings.HasSuffix(result, ColorReset) {
+				t.Fatalf("expected ColorReset suffix, got %q", result)
+			}
+		})
+	}
+}
+
 func TestFormatCostColored(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
This PR adds cache hit rate tracking and visualization to the status line. It introduces a new cache package that calculates Claude API cache performance metrics from transcript data and displays them with color-coded indicators.

## Key Changes

- **New cache package** (`pkg/cache/tracker.go`):
  - `Calculate()` function extracts cache metrics from transcript lines
  - Skips sidechain requests and processes the most recent valid message
  - Computes hit rate as percentage of cache-read tokens vs total input tokens
  - `Format()` function formats cache info for display

- **Cache display formatting** (`pkg/statusline/builder.go`):
  - `FormatCacheDisplay()` renders cache hit rate with color coding:
    - Green (≥80% hit rate)
    - Yellow (50-79% hit rate)
    - Red (<50% hit rate)

- **Configuration updates** (`pkg/config/config.go`):
  - Added `CacheHitRate` field to `SectionVisibility` struct
  - Enabled by default in `DefaultConfig()`

- **Integration** (`cmd/statusline/main.go`):
  - Added concurrent goroutine to calculate cache metrics
  - Integrated cache display into status line output with priority 12
  - Increased result channel buffer from 12 to 13

- **Comprehensive test coverage** (`pkg/cache/tracker_test.go`):
  - Tests for normal cache calculations
  - Sidechain filtering behavior
  - Edge cases (zero total, all cache read, no cache read, empty lines)
  - Format function validation

## Implementation Details

The cache tracker processes transcript lines in reverse order to find the most recent non-sidechain message with usage data. It calculates hit rate as: `(cache_read_input_tokens / (input_tokens + cache_read_input_tokens + cache_creation_input_tokens)) * 100`

The display is color-coded to provide quick visual feedback on cache efficiency, helping users understand API performance at a glance.

https://claude.ai/code/session_01VcisY11pp5wun3EbkfXvKE