### PR TITLE
fix: use input.ContextWindow as primary source for token tracking

### DIFF
--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -25,6 +25,11 @@ import (
 	"github.com/howie/claude-code-omystatusline/pkg/transcript"
 )
 
+const (
+	maxTokensSourceContextWindow  = "ContextWindow"
+	maxTokensSourceModelInference = "model-inference"
+)
+
 func main() {
 	var input statusline.Input
 	if err := json.NewDecoder(os.Stdin).Decode(&input); err != nil {
@@ -52,18 +57,21 @@ func main() {
 	// 2. transcript 最後一筆 usage 的 message.model → contextWindowForModel()
 	// 3. fallback 到 input.Model.ID → contextWindowForModel()
 	// 4. STATUSLINE_MAX_TOKENS 環境變數可覆寫（effectiveModelID 保留供 debug 輸出）
-	effectiveModelID := context.InferModelFromLines(lines)
-	if effectiveModelID == "" {
-		effectiveModelID = input.Model.ID
-	}
+	hasContextWindow := input.ContextWindow.ContextWindowSize > 0
+	var effectiveModelID string
 	var maxTokens int
 	var maxTokensSource string
-	if input.ContextWindow.ContextWindowSize > 0 {
+	if hasContextWindow {
 		maxTokens = input.ContextWindow.ContextWindowSize
-		maxTokensSource = "ContextWindow"
+		maxTokensSource = maxTokensSourceContextWindow
+		effectiveModelID = input.Model.ID
 	} else {
+		effectiveModelID = context.InferModelFromLines(lines)
+		if effectiveModelID == "" {
+			effectiveModelID = input.Model.ID
+		}
 		maxTokens = contextWindowForModel(effectiveModelID)
-		maxTokensSource = "model-inference"
+		maxTokensSource = maxTokensSourceModelInference
 	}
 	if envMax := os.Getenv("STATUSLINE_MAX_TOKENS"); envMax != "" {
 		v, err := strconv.Atoi(envMax)
@@ -92,7 +100,7 @@ func main() {
 			// 導致 transcript 解析誤判為 NoUsageData（📡）。ContextWindow 則不受此影響。
 			// tokens==0 時顯示 0%（而非 📡）：代表 session 尚未完成第一次 API call，
 			// 不是「無法取得資料」，與 metadata-only transcript 情境語意不同。
-			if input.ContextWindow.ContextWindowSize > 0 {
+			if hasContextWindow {
 				u := input.ContextWindow.CurrentUsage
 				// output tokens 不計入：context window 壓力由 input+cache 決定，
 				// 與 usageFromLines 的計算方式一致（見 tracker.go）。
@@ -101,7 +109,6 @@ func main() {
 				return
 			}
 			// Fallback：較舊的 Claude Code 版本沒有 context_window 欄位，從 transcript 解析。
-			// lines == nil（不論 err 是否有值）時無可解析的資料，直接回傳 nil 使 context 段落為空。
 			if lines == nil {
 				results <- statusline.Result{Type: "context", Data: (*context.ContextData)(nil)}
 				return

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -47,15 +47,21 @@ func main() {
 		fmt.Fprintf(os.Stderr, "statusline: failed to read transcript %q: %v\n", input.TranscriptPath, err)
 	}
 
-	// 決定 context window 大小：
-	// 1. transcript 最後一筆 usage 的 message.model（最準確，對應實際產生 token 的模型）
-	// 2. fallback 到 input.Model.ID（session 當前設定的模型）
-	// 3. STATUSLINE_MAX_TOKENS 環境變數可覆寫 maxTokens（effectiveModelID 保留供 debug 輸出）
+	// 決定 context window 大小與 maxTokens（優先級由高到低）：
+	// 1. input.ContextWindow.ContextWindowSize（Claude Code 直接提供，最準確，worktree 也有效）
+	// 2. transcript 最後一筆 usage 的 message.model → contextWindowForModel()
+	// 3. fallback 到 input.Model.ID → contextWindowForModel()
+	// 4. STATUSLINE_MAX_TOKENS 環境變數可覆寫（effectiveModelID 保留供 debug 輸出）
 	effectiveModelID := context.InferModelFromLines(lines)
 	if effectiveModelID == "" {
 		effectiveModelID = input.Model.ID
 	}
-	maxTokens := contextWindowForModel(effectiveModelID)
+	var maxTokens int
+	if input.ContextWindow.ContextWindowSize > 0 {
+		maxTokens = input.ContextWindow.ContextWindowSize
+	} else {
+		maxTokens = contextWindowForModel(effectiveModelID)
+	}
 	if envMax := os.Getenv("STATUSLINE_MAX_TOKENS"); envMax != "" {
 		v, err := strconv.Atoi(envMax)
 		switch {
@@ -78,9 +84,16 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// Only suppress context on actual read error (err != nil).
-			// Empty transcript path (new session) returns (nil, nil) and should
-			// still produce the zero-usage display via AnalyzeDetailedFromLines(nil).
+			// 優先使用 input.ContextWindow（Claude Code 直接提供，worktree session 也有效）。
+			// Worktree session 的 transcript_path 指向只含 metadata 的小檔案，
+			// 導致 transcript 解析誤判為 NoUsageData（📡）。ContextWindow 則不受此影響。
+			if input.ContextWindow.ContextWindowSize > 0 {
+				u := input.ContextWindow.CurrentUsage
+				tokens := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+				results <- statusline.Result{Type: "context", Data: context.BuildFromTokens(tokens, maxTokens)}
+				return
+			}
+			// Fallback：較舊的 Claude Code 版本沒有 context_window 欄位，從 transcript 解析。
 			if lines == nil && err != nil {
 				results <- statusline.Result{Type: "context", Data: (*context.ContextData)(nil)}
 				return

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -57,10 +57,13 @@ func main() {
 		effectiveModelID = input.Model.ID
 	}
 	var maxTokens int
+	var maxTokensSource string
 	if input.ContextWindow.ContextWindowSize > 0 {
 		maxTokens = input.ContextWindow.ContextWindowSize
+		maxTokensSource = "ContextWindow"
 	} else {
 		maxTokens = contextWindowForModel(effectiveModelID)
+		maxTokensSource = "model-inference"
 	}
 	if envMax := os.Getenv("STATUSLINE_MAX_TOKENS"); envMax != "" {
 		v, err := strconv.Atoi(envMax)
@@ -87,14 +90,19 @@ func main() {
 			// 優先使用 input.ContextWindow（Claude Code 直接提供，worktree session 也有效）。
 			// Worktree session 的 transcript_path 指向只含 metadata 的小檔案，
 			// 導致 transcript 解析誤判為 NoUsageData（📡）。ContextWindow 則不受此影響。
+			// tokens==0 時顯示 0%（而非 📡）：代表 session 尚未完成第一次 API call，
+			// 不是「無法取得資料」，與 metadata-only transcript 情境語意不同。
 			if input.ContextWindow.ContextWindowSize > 0 {
 				u := input.ContextWindow.CurrentUsage
+				// output tokens 不計入：context window 壓力由 input+cache 決定，
+				// 與 usageFromLines 的計算方式一致（見 tracker.go）。
 				tokens := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
 				results <- statusline.Result{Type: "context", Data: context.BuildFromTokens(tokens, maxTokens)}
 				return
 			}
 			// Fallback：較舊的 Claude Code 版本沒有 context_window 欄位，從 transcript 解析。
-			if lines == nil && err != nil {
+			// lines == nil（不論 err 是否有值）時無可解析的資料，直接回傳 nil 使 context 段落為空。
+			if lines == nil {
 				results <- statusline.Result{Type: "context", Data: (*context.ContextData)(nil)}
 				return
 			}
@@ -411,8 +419,8 @@ func main() {
 		{Content: statusline.ColorReset, Priority: 0},
 	}
 	if os.Getenv("STATUSLINE_DEBUG") == "1" {
-		fmt.Fprintf(os.Stderr, "[debug] termWidth=%d overflowMode=%q tokens=%d hasData=%v effectiveModel=%q maxTokens=%d\n",
-			termWidth, cfg.OverflowMode, contextTokens, contextHasData, effectiveModelID, maxTokens)
+		fmt.Fprintf(os.Stderr, "[debug] termWidth=%d overflowMode=%q tokens=%d hasData=%v effectiveModel=%q maxTokens=%d maxTokensSource=%q\n",
+			termWidth, cfg.OverflowMode, contextTokens, contextHasData, effectiveModelID, maxTokens, maxTokensSource)
 		total := 0
 		for _, seg := range line1Segments {
 			if seg.Content == "" {

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -109,7 +109,10 @@ func main() {
 				return
 			}
 			// Fallback：較舊的 Claude Code 版本沒有 context_window 欄位，從 transcript 解析。
-			if lines == nil {
+			// lines == nil && err != nil → 實際讀取失敗，不顯示 context 段落。
+			// lines == nil && err == nil → 空 transcript_path（新 session 尚無資料），
+			// 仍傳入 nil 給 AnalyzeDetailedFromLines，顯示 📡 而非完全隱藏段落。
+			if lines == nil && err != nil {
 				results <- statusline.Result{Type: "context", Data: (*context.ContextData)(nil)}
 				return
 			}

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -115,7 +115,7 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if lines == nil && err != nil {
+			if lines == nil {
 				results <- statusline.Result{Type: "message", Data: ""}
 				return
 			}

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/howie/claude-code-omystatusline/pkg/context"
 	"github.com/howie/claude-code-omystatusline/pkg/statusline"
+	"github.com/howie/claude-code-omystatusline/pkg/terminal"
 )
 
 func TestFormatSegments(t *testing.T) {
@@ -43,6 +44,65 @@ func TestFormatSegments(t *testing.T) {
 		got := formatSegments(segs, 80, "")
 		if !strings.Contains(got, "\n") {
 			t.Error("empty overflow_mode should fall back to wrap behavior")
+		}
+	})
+}
+
+// TestContextWindowMaxTokens 驗證 maxTokens 優先順序：
+// ContextWindowSize > 0 時優先使用，否則 fallback 到 contextWindowForModel。
+func TestContextWindowMaxTokens(t *testing.T) {
+	orig := context.RenderMode
+	context.RenderMode = terminal.ModeTrueColor
+	defer func() { context.RenderMode = orig }()
+
+	t.Run("ContextWindowSize>0 takes priority over model inference", func(t *testing.T) {
+		// 93545 tokens / 500000 window = 18%
+		tokens := 1 + 694 + 92850
+		ctxData := context.BuildFromTokens(tokens, 500_000)
+		if ctxData.NoUsageData {
+			t.Error("ContextWindow path must not set NoUsageData")
+		}
+		if ctxData.Tokens != tokens {
+			t.Errorf("Tokens = %d, want %d", ctxData.Tokens, tokens)
+		}
+		wantPct := tokens * 100 / 500_000
+		if ctxData.Percentage != wantPct {
+			t.Errorf("Percentage = %d, want %d", ctxData.Percentage, wantPct)
+		}
+	})
+
+	t.Run("zero ContextWindowSize falls back to model inference", func(t *testing.T) {
+		// ContextWindowSize==0 → contextWindowForModel used; verify the function exists
+		got := contextWindowForModel("claude-sonnet-4-6")
+		if got != 500_000 {
+			t.Errorf("contextWindowForModel(sonnet) = %d, want 500000", got)
+		}
+	})
+
+	t.Run("ContextWindow with zero tokens shows 0pct not NoUsageData", func(t *testing.T) {
+		// Session started but no API call yet: context_window_size>0, current_usage all zeros.
+		ctxData := context.BuildFromTokens(0, 200_000)
+		if ctxData.NoUsageData {
+			t.Error("zero tokens from ContextWindow must show 0%%, not 📡 (NoUsageData)")
+		}
+		if ctxData.Percentage != 0 {
+			t.Errorf("Percentage = %d, want 0", ctxData.Percentage)
+		}
+		if strings.Contains(ctxData.Info, "📡") {
+			t.Errorf("Info must not contain 📡 for ContextWindow zero-token session, got %q", ctxData.Info)
+		}
+	})
+
+	t.Run("tokens exceeding maxTokens clamps to 100pct", func(t *testing.T) {
+		ctxData := context.BuildFromTokens(600_000, 500_000)
+		if ctxData.Percentage != 100 {
+			t.Errorf("Percentage = %d, want 100 when tokens > maxTokens", ctxData.Percentage)
+		}
+		if ctxData.Tokens != 600_000 {
+			t.Errorf("Tokens = %d, want 600000 (raw value preserved)", ctxData.Tokens)
+		}
+		if !strings.Contains(ctxData.Info, "600k") {
+			t.Errorf("Info should show raw token count even when clamped, got %q", ctxData.Info)
 		}
 	})
 }

--- a/pkg/context/tracker.go
+++ b/pkg/context/tracker.go
@@ -121,6 +121,9 @@ func FormatContextParts(contextLength, maxTokens int) (bar string, info string) 
 		maxTokens = DefaultMaxTokens
 	}
 	percentage := int(float64(contextLength) * 100.0 / float64(maxTokens))
+	if percentage < 0 {
+		percentage = 0
+	}
 	if percentage > 100 {
 		percentage = 100
 	}
@@ -156,6 +159,9 @@ func buildContextData(contextLength, maxTokens int, noUsageData bool) *ContextDa
 	}
 
 	percentage := int(float64(contextLength) * 100.0 / float64(maxTokens))
+	if percentage < 0 {
+		percentage = 0
+	}
 	if percentage > 100 {
 		percentage = 100
 	}

--- a/pkg/context/tracker.go
+++ b/pkg/context/tracker.go
@@ -43,6 +43,16 @@ func (c *ContextData) HasData() bool {
 	return !c.NoUsageData && c.Tokens > 0
 }
 
+// BuildFromTokens 從直接提供的 token 數建立 ContextData，供 input.ContextWindow 使用。
+// 當 tokens == 0 時回傳零使用量（不標記 NoUsageData，因為這是有意義的 0%，
+// 而非「無法取得資料」）。
+func BuildFromTokens(tokens, maxTokens int) *ContextData {
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+	return buildContextData(tokens, maxTokens, false)
+}
+
 // Analyze 分析 Context 使用量（向後相容）
 // maxTokens <= 0 時使用 DefaultMaxTokens
 // 讀取失敗時輸出錯誤訊息至 stderr 並回傳零值進度條。

--- a/pkg/context/tracker_test.go
+++ b/pkg/context/tracker_test.go
@@ -488,3 +488,65 @@ func TestInferModelFromLines(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildFromTokens 驗證 BuildFromTokens 行為，模擬 input.ContextWindow 使用場景（含 worktree）。
+func TestBuildFromTokens(t *testing.T) {
+	orig := RenderMode
+	RenderMode = terminal.ModeTrueColor
+	defer func() { RenderMode = orig }()
+
+	t.Run("worktree session with real usage", func(t *testing.T) {
+		// 模擬：transcript_path 指向 metadata-only worktree 檔案，但 input.ContextWindow 有正確資料
+		tokens := 1 + 694 + 92850 // input + cache_creation + cache_read（93545）
+		data := BuildFromTokens(tokens, 500_000)
+		if data == nil {
+			t.Fatal("expected non-nil ContextData")
+		}
+		if data.NoUsageData {
+			t.Error("BuildFromTokens must never set NoUsageData: usage came directly from Claude Code")
+		}
+		if data.Tokens != tokens {
+			t.Errorf("Tokens = %d, want %d", data.Tokens, tokens)
+		}
+		wantPct := int(float64(tokens) * 100.0 / 500_000)
+		if data.Percentage != wantPct {
+			t.Errorf("Percentage = %d, want %d", data.Percentage, wantPct)
+		}
+		if data.HasData() != (tokens > 0) {
+			t.Errorf("HasData() = %v, want %v", data.HasData(), tokens > 0)
+		}
+		if !strings.Contains(data.Info, "93k") {
+			t.Errorf("Info should contain token count '93k', got %q", data.Info)
+		}
+	})
+
+	t.Run("zero tokens at session start", func(t *testing.T) {
+		// 新 session 尚未有 API call：顯示 0%（不是 📡）
+		data := BuildFromTokens(0, 200_000)
+		if data == nil {
+			t.Fatal("expected non-nil ContextData")
+		}
+		if data.NoUsageData {
+			t.Error("BuildFromTokens with tokens=0 must NOT set NoUsageData: it is a valid 0%, not metadata-only")
+		}
+		if data.Percentage != 0 {
+			t.Errorf("Percentage = %d, want 0", data.Percentage)
+		}
+		if data.HasData() {
+			t.Error("HasData() must be false when tokens=0")
+		}
+		if strings.Contains(data.Info, "📡") {
+			t.Errorf("Info must not contain 📡 for zero-token session from ContextWindow, got %q", data.Info)
+		}
+	})
+
+	t.Run("zero maxTokens uses DefaultMaxTokens", func(t *testing.T) {
+		data := BuildFromTokens(DefaultMaxTokens/2, 0)
+		if data == nil {
+			t.Fatal("expected non-nil ContextData")
+		}
+		if data.Percentage != 50 {
+			t.Errorf("Percentage = %d, want 50 (DefaultMaxTokens/2 out of DefaultMaxTokens)", data.Percentage)
+		}
+	})
+}

--- a/pkg/statusline/model.go
+++ b/pkg/statusline/model.go
@@ -28,17 +28,24 @@ type Input struct {
 	// ContextWindow 為 Claude Code 直接提供的 context window 使用量。
 	// 此欄位比 transcript 解析更準確（worktree session 也能正確讀取），
 	// 應優先使用此欄位，transcript 作為 fallback。
+	// ContextWindowSize == 0 表示舊版 Claude Code 不提供此資料；> 0 才視為有效。
 	ContextWindow struct {
+		// TotalInputTokens / TotalOutputTokens：整個 session 的累計量，僅供參考，不用於進度條。
 		TotalInputTokens  int `json:"total_input_tokens,omitempty"`
 		TotalOutputTokens int `json:"total_output_tokens,omitempty"`
-		// ContextWindowSize 為此 session 實際使用的 context window 大小
+		// ContextWindowSize 為此 session 實際使用的 context window 大小（非理論最大值）。
 		ContextWindowSize int `json:"context_window_size,omitempty"`
 		CurrentUsage      struct {
-			InputTokens              int `json:"input_tokens,omitempty"`
+			InputTokens int `json:"input_tokens,omitempty"`
+			// OutputTokens 已解析但不計入 context 使用量：
+			// context window 壓力由 input+cache tokens 決定；output tokens 延伸自同一 window，
+			// 不單獨占用 context 空間。與 tracker.go usageFromLines 的計算方式一致。
 			OutputTokens             int `json:"output_tokens,omitempty"`
 			CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 			CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 		} `json:"current_usage,omitempty"`
+		// UsedPercentage / RemainingPercentage：由 Claude Code 計算，僅供參考。
+		// 進度條使用 BuildFromTokens 自行計算，保持與 bar 渲染邏輯一致。
 		UsedPercentage      int `json:"used_percentage,omitempty"`
 		RemainingPercentage int `json:"remaining_percentage,omitempty"`
 	} `json:"context_window,omitempty"`

--- a/pkg/statusline/model.go
+++ b/pkg/statusline/model.go
@@ -25,6 +25,23 @@ type Input struct {
 		TotalLinesAdded    int     `json:"total_lines_added,omitempty"`
 		TotalLinesRemoved  int     `json:"total_lines_removed,omitempty"`
 	} `json:"cost,omitempty"` // v2.0.25+ 新增
+	// ContextWindow 為 Claude Code 直接提供的 context window 使用量。
+	// 此欄位比 transcript 解析更準確（worktree session 也能正確讀取），
+	// 應優先使用此欄位，transcript 作為 fallback。
+	ContextWindow struct {
+		TotalInputTokens  int `json:"total_input_tokens,omitempty"`
+		TotalOutputTokens int `json:"total_output_tokens,omitempty"`
+		// ContextWindowSize 為此 session 實際使用的 context window 大小
+		ContextWindowSize int `json:"context_window_size,omitempty"`
+		CurrentUsage      struct {
+			InputTokens              int `json:"input_tokens,omitempty"`
+			OutputTokens             int `json:"output_tokens,omitempty"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+		} `json:"current_usage,omitempty"`
+		UsedPercentage      int `json:"used_percentage,omitempty"`
+		RemainingPercentage int `json:"remaining_percentage,omitempty"`
+	} `json:"context_window,omitempty"`
 	AgentID   string `json:"agent_id,omitempty"`
 	AgentType string `json:"agent_type,omitempty"`
 	Worktree  struct {


### PR DESCRIPTION
## Summary

- **Root cause**: Worktree sessions receive a `transcript_path` pointing to a worktree-specific file containing only metadata (`pr-link`, `agent-name` entries), causing the status bar to display 📡 (NoUsageData) despite active token usage
- **Fix**: Parse `input.context_window` from the stdin JSON — Claude Code provides authoritative context window data here, unaffected by worktree transcript path routing
- **Backwards compat**: Falls back to transcript-based calculation when `context_window_size == 0` (older Claude Code versions)

## Changes

| File | Change |
|------|--------|
| `pkg/statusline/model.go` | Add `ContextWindow` struct (`context_window_size`, `current_usage`, `used_percentage`) |
| `pkg/context/tracker.go` | New `BuildFromTokens(tokens, maxTokens)` — direct token→ContextData, never sets `NoUsageData` |
| `cmd/statusline/main.go` | Prefer `input.ContextWindow` when `context_window_size > 0`; use as `maxTokens` override |
| `pkg/context/tracker_test.go` | `TestBuildFromTokens`: worktree scenario, zero-token start, zero maxTokens fallback |

## Test plan

- [ ] `go test ./...` passes (all 3 new subtests in `TestBuildFromTokens`)
- [ ] Worktree session: was `░░░░░░░░░░ 📡`, now shows actual `█░░░░░░░░░ 18% 93k`
- [ ] Normal session with `context_window`: reads `context_window_size` directly (no model inference needed)
- [ ] Old Claude Code (no `context_window`): falls back to transcript parsing unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)