### PR TITLE
fix: update context window fallback to official 1M specs for Sonnet 4.6/Opus 4.6+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ statusline-go
 /voice-reminder
 tmp/
 output/
-.specify/.pr-review/
+.pr-review/
 .antigravitycli/

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ statusline-go
 /voice-reminder
 tmp/
 output/
-.specify/
+.specify/.pr-review/
+.antigravitycli/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,8 @@ Formatted status line output to stdout
 - `AnalyzeDetailedFromLines(lines, maxTokens)` - returns `ContextData` with bar, info, percentage
 - `InferModelFromLines(lines)` - reads `message.model` from last usage entry; used for mixed-model sessions
 - `maxTokens` source of truth priority: transcript `message.model` → `input.Model.ID` → `STATUSLINE_MAX_TOKENS` env var
-- Model context window mapping (in `contextWindowForModel()`, `cmd/statusline/main.go`; **empirically calibrated**, not theoretical max):
-  - Haiku: 200K | Sonnet: 500K | Opus: 800K | unknown non-empty: 500K | empty: `DefaultMaxTokens`
+- Model context window mapping (in `contextWindowForModel()`, `cmd/statusline/main.go`; **official Anthropic specs**, fallback only):
+  - Haiku 4.5: 200K | Sonnet 4.6+: 1M | Sonnet 4.5-: 200K | Opus 4.6/4.7+: 1M | Opus 4.5-: 200K | unknown non-empty: 200K | empty: `DefaultMaxTokens`
 - Generates visual progress bar (██████░░░░ format)
 - Color-coded warnings: green (<60%), gold (60-80%), red (≥80%)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,8 @@ Formatted status line output to stdout
 - `InferModelFromLines(lines)` - reads `message.model` from last usage entry; used for mixed-model sessions
 - `maxTokens` source of truth priority: transcript `message.model` → `input.Model.ID` → `STATUSLINE_MAX_TOKENS` env var
 - Model context window mapping (in `contextWindowForModel()`, `cmd/statusline/main.go`; **official Anthropic specs**, fallback only):
-  - Haiku 4.5: 200K | Sonnet 4.6+: 1M | Sonnet 4.5-: 200K | Opus 4.6/4.7+: 1M | Opus 4.5-: 200K | unknown non-empty: 200K | empty: `DefaultMaxTokens`
+  - Haiku: 200K | Sonnet minor ≥ 6 (4.6+): 1M | Sonnet minor < 6: 200K | Opus minor ≥ 6 (4.6+): 1M | Opus minor < 6: 200K | unknown non-empty: 200K | empty: `DefaultMaxTokens`
+  - Version parsed via `claudeModelMinorVersion()`: matches `-4-X` pattern in model ID
 - Generates visual progress bar (██████░░░░ format)
 - Color-coded warnings: green (<60%), gold (60-80%), red (≥80%)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,8 @@ Formatted status line output to stdout
 - `InferModelFromLines(lines)` - reads `message.model` from last usage entry; used for mixed-model sessions
 - `maxTokens` source of truth priority: transcript `message.model` → `input.Model.ID` → `STATUSLINE_MAX_TOKENS` env var
 - Model context window mapping (in `contextWindowForModel()`, `cmd/statusline/main.go`; **official Anthropic specs**, fallback only):
-  - Haiku: 200K | Sonnet minor ≥ 6 (4.6+): 1M | Sonnet minor < 6: 200K | Opus minor ≥ 6 (4.6+): 1M | Opus minor < 6: 200K | unknown non-empty: 200K | empty: `DefaultMaxTokens`
-  - Version parsed via `claudeModelMinorVersion()`: matches `-4-X` pattern in model ID
+  - Haiku: 200K | Sonnet/Opus major ≥ 5 OR (major==4 AND minor ≥ 6): 1M | others: 200K | unknown non-empty: 200K | empty: `DefaultMaxTokens`
+  - Version parsed via `claudeModelVersion()`: scans from end for two consecutive small integers (< 100), ignores date suffixes
 - Generates visual progress bar (██████░░░░ format)
 - Color-coded warnings: green (<60%), gold (60-80%), red (≥80%)
 

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -505,22 +505,22 @@ func formatSegments(segments []statusline.Segment, maxWidth int, overflowMode st
 }
 
 // contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens）。
-// 依官方 Anthropic 規格：Opus 4.6/4.7、Sonnet 4.6 為 1M；其餘含 Haiku 為 200K。
+// 依官方 Anthropic 規格：minor version >= 6 的 Sonnet/Opus 為 1M；Haiku 及以下版本為 200K。
 // 此函式僅作 fallback；現代 Claude Code 版本會透過 input.ContextWindow 提供精確值。
 func contextWindowForModel(modelID string) int {
 	id := strings.ToLower(modelID)
 	switch {
 	case strings.Contains(id, "haiku"):
 		return 200_000
-	// Sonnet 4.6+ → 1M；4.5 以下 → 200K
-	case strings.Contains(id, "sonnet-4-6"):
-		return 1_000_000
 	case strings.Contains(id, "sonnet"):
+		if claudeModelMinorVersion(id) >= 6 {
+			return 1_000_000
+		}
 		return 200_000
-	// Opus 4.6/4.7+ → 1M；4.5 以下 → 200K
-	case strings.Contains(id, "opus-4-6"), strings.Contains(id, "opus-4-7"):
-		return 1_000_000
 	case strings.Contains(id, "opus"):
+		if claudeModelMinorVersion(id) >= 6 {
+			return 1_000_000
+		}
 		return 200_000
 	case id != "":
 		fmt.Fprintf(os.Stderr, "statusline: unknown model %q, using 200K context window fallback\n", modelID)
@@ -528,6 +528,30 @@ func contextWindowForModel(modelID string) int {
 	default:
 		return context.DefaultMaxTokens
 	}
+}
+
+// claudeModelMinorVersion 解析 claude-*-4-X 格式的 minor version 數字。
+// 例如 "claude-sonnet-4-6" → 6，"claude-opus-4-7-20251001" → 7。
+// 解析失敗時回傳 -1（確保 fallback 走保守路徑）。
+func claudeModelMinorVersion(id string) int {
+	const prefix = "-4-"
+	idx := strings.Index(id, prefix)
+	if idx < 0 {
+		return -1
+	}
+	rest := id[idx+len(prefix):]
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return -1
+	}
+	v, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return -1
+	}
+	return v
 }
 
 func joinWithSep(parts []string, sep string) string {

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -505,7 +505,7 @@ func formatSegments(segments []statusline.Segment, maxWidth int, overflowMode st
 }
 
 // contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens）。
-// 依官方 Anthropic 規格：minor version >= 6 的 Sonnet/Opus 為 1M；Haiku 及以下版本為 200K。
+// 依官方 Anthropic 規格：Sonnet/Opus major >= 5，或 major == 4 且 minor >= 6 時為 1M；其餘為 200K。
 // 此函式僅作 fallback；現代 Claude Code 版本會透過 input.ContextWindow 提供精確值。
 func contextWindowForModel(modelID string) int {
 	id := strings.ToLower(modelID)
@@ -513,12 +513,12 @@ func contextWindowForModel(modelID string) int {
 	case strings.Contains(id, "haiku"):
 		return 200_000
 	case strings.Contains(id, "sonnet"):
-		if claudeModelMinorVersion(id) >= 6 {
+		if claudeModelIs1M(id) {
 			return 1_000_000
 		}
 		return 200_000
 	case strings.Contains(id, "opus"):
-		if claudeModelMinorVersion(id) >= 6 {
+		if claudeModelIs1M(id) {
 			return 1_000_000
 		}
 		return 200_000
@@ -530,28 +530,33 @@ func contextWindowForModel(modelID string) int {
 	}
 }
 
-// claudeModelMinorVersion 解析 claude-*-4-X 格式的 minor version 數字。
-// 例如 "claude-sonnet-4-6" → 6，"claude-opus-4-7-20251001" → 7。
-// 解析失敗時回傳 -1（確保 fallback 走保守路徑）。
-func claudeModelMinorVersion(id string) int {
-	const prefix = "-4-"
-	idx := strings.Index(id, prefix)
-	if idx < 0 {
-		return -1
+// claudeModelIs1M 回報 claude 模型是否有 1M context window。
+// 解析 claude-*-{major}-{minor}[-date] 中的 major/minor，版本規則：
+//   - major >= 5 → 1M（為未來大版本預留）
+//   - major == 4 && minor >= 6 → 1M（Sonnet 4.6+、Opus 4.6+）
+//   - 其他 → false（保守 fallback）
+func claudeModelIs1M(id string) bool {
+	major, minor := claudeModelVersion(id)
+	return major >= 5 || (major == 4 && minor >= 6)
+}
+
+// claudeModelVersion 從 claude-*-{major}-{minor}[-date] 格式解析 (major, minor)。
+// 從 ID 末端向前掃描，找最後兩個連續的小整數 token（< 100，避免誤認 date suffix）。
+// 解析失敗時回傳 (-1, -1)。
+func claudeModelVersion(id string) (int, int) {
+	parts := strings.Split(id, "-")
+	for i := len(parts) - 1; i >= 1; i-- {
+		minor, err1 := strconv.Atoi(parts[i])
+		major, err2 := strconv.Atoi(parts[i-1])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		// 限制在合理版本範圍內（排除 date suffix 如 20250514）
+		if major > 0 && major < 100 && minor >= 0 && minor < 100 {
+			return major, minor
+		}
 	}
-	rest := id[idx+len(prefix):]
-	end := 0
-	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
-		end++
-	}
-	if end == 0 {
-		return -1
-	}
-	v, err := strconv.Atoi(rest[:end])
-	if err != nil {
-		return -1
-	}
-	return v
+	return -1, -1
 }
 
 func joinWithSep(parts []string, sep string) string {

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -511,7 +511,7 @@ func contextWindowForModel(modelID string) int {
 	id := strings.ToLower(modelID)
 	switch {
 	case strings.Contains(id, "haiku"):
-		return 200_000
+		return 200_000 // Haiku 從未超過 200K；如有更大版本請重新評估
 	case strings.Contains(id, "sonnet"):
 		if claudeModelIs1M(id) {
 			return 1_000_000

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -504,22 +504,27 @@ func formatSegments(segments []statusline.Segment, maxWidth int, overflowMode st
 	}
 }
 
-// contextWindowForModel 根據模型 ID 回傳有效 context window 大小（tokens）。
-// Haiku/Sonnet 數值反推自實測 auto-compact 觸發點（非模型理論最大值）；
-// Opus 數值為保守估計（尚無足夠觸發觀測，預留較大空間）。
-// Haiku: 200K | Sonnet: 500K | Opus: 800K | 未知非空: 500K（保守值）| 空字串: DefaultMaxTokens。
+// contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens）。
+// 依官方 Anthropic 規格：Opus 4.6/4.7、Sonnet 4.6 為 1M；其餘含 Haiku 為 200K。
+// 此函式僅作 fallback；現代 Claude Code 版本會透過 input.ContextWindow 提供精確值。
 func contextWindowForModel(modelID string) int {
 	id := strings.ToLower(modelID)
 	switch {
 	case strings.Contains(id, "haiku"):
 		return 200_000
+	// Sonnet 4.6+ → 1M；4.5 以下 → 200K
+	case strings.Contains(id, "sonnet-4-6"):
+		return 1_000_000
 	case strings.Contains(id, "sonnet"):
-		return 500_000
+		return 200_000
+	// Opus 4.6/4.7+ → 1M；4.5 以下 → 200K
+	case strings.Contains(id, "opus-4-6"), strings.Contains(id, "opus-4-7"):
+		return 1_000_000
 	case strings.Contains(id, "opus"):
-		return 800_000
+		return 200_000
 	case id != "":
-		fmt.Fprintf(os.Stderr, "statusline: unknown model %q, using 500K context window default\n", modelID)
-		return 500_000
+		fmt.Fprintf(os.Stderr, "statusline: unknown model %q, using 200K context window fallback\n", modelID)
+		return 200_000
 	default:
 		return context.DefaultMaxTokens
 	}

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -74,8 +74,8 @@ func TestContextWindowMaxTokens(t *testing.T) {
 	t.Run("zero ContextWindowSize falls back to model inference", func(t *testing.T) {
 		// ContextWindowSize==0 → contextWindowForModel used; verify the function exists
 		got := contextWindowForModel("claude-sonnet-4-6")
-		if got != 500_000 {
-			t.Errorf("contextWindowForModel(sonnet) = %d, want 500000", got)
+		if got != 1_000_000 {
+			t.Errorf("contextWindowForModel(sonnet-4-6) = %d, want 1000000", got)
 		}
 	})
 
@@ -113,19 +113,25 @@ func TestContextWindowForModel(t *testing.T) {
 		modelID string
 		want    int
 	}{
-		// Haiku: 200K（不變）
+		// Haiku: 200K（官方規格，不變）
 		{"haiku-base", "claude-haiku-4-5", 200_000},
 		{"haiku-dated-suffix", "claude-haiku-4-5-20251001", 200_000},
 		{"haiku-uppercase", "Claude-Haiku-4-5", 200_000},
-		// Sonnet: 500K（經驗校準，反推自 ~357K compact 點 ÷ 70%）
-		{"sonnet-46", "claude-sonnet-4-6", 500_000},
-		{"sonnet-45", "claude-sonnet-4-5", 500_000},
-		{"sonnet-uppercase", "CLAUDE-SONNET-4-6", 500_000},
-		// Opus: 800K（Opus context 較大，預留更多空間）
-		{"opus-47", "claude-opus-4-7", 800_000},
-		{"opus-46", "claude-opus-4-6", 800_000},
-		// 未知非空模型：保守 fallback 500K
-		{"unknown-future", "claude-future-1", 500_000},
+		// Sonnet 4.6+: 1M（官方規格）
+		{"sonnet-46", "claude-sonnet-4-6", 1_000_000},
+		{"sonnet-uppercase", "CLAUDE-SONNET-4-6", 1_000_000},
+		// Sonnet 4.5 以下: 200K（官方規格）
+		{"sonnet-45", "claude-sonnet-4-5", 200_000},
+		{"sonnet-45-dated", "claude-sonnet-4-5-20250929", 200_000},
+		// Opus 4.6/4.7: 1M（官方規格）
+		{"opus-47", "claude-opus-4-7", 1_000_000},
+		{"opus-46", "claude-opus-4-6", 1_000_000},
+		// Opus 4.5 以下: 200K（官方規格）
+		{"opus-45", "claude-opus-4-5", 200_000},
+		{"opus-45-dated", "claude-opus-4-5-20251101", 200_000},
+		{"opus-41", "claude-opus-4-1-20250805", 200_000},
+		// 未知非空模型：保守 fallback 200K
+		{"unknown-future", "claude-future-1", 200_000},
 		// 空字串：DefaultMaxTokens
 		{"empty-fallback", "", context.DefaultMaxTokens},
 	}

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -107,6 +107,37 @@ func TestContextWindowMaxTokens(t *testing.T) {
 	})
 }
 
+func TestClaudeModelVersion(t *testing.T) {
+	cases := []struct {
+		id        string
+		wantMajor int
+		wantMinor int
+	}{
+		{"claude-sonnet-4-6", 4, 6},
+		{"claude-opus-4-7-20251001", 4, 7},
+		{"claude-sonnet-4-5-20250929", 4, 5},
+		{"claude-sonnet-5-0", 5, 0},
+		{"claude-opus-4-1-20250805", 4, 1},
+		{"claude-haiku-4-5", 4, 5},
+		// date-only format (no minor) → not parseable as valid version
+		{"claude-sonnet-4-20250514", -1, -1},
+		// trailing prefix, no digit
+		{"claude-sonnet-4-", -1, -1},
+		// unknown format
+		{"claude-future-1", -1, -1},
+		{"", -1, -1},
+		{"sonnet-4-10", 4, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			maj, min := claudeModelVersion(strings.ToLower(tc.id))
+			if maj != tc.wantMajor || min != tc.wantMinor {
+				t.Errorf("claudeModelVersion(%q) = (%d, %d), want (%d, %d)", tc.id, maj, min, tc.wantMajor, tc.wantMinor)
+			}
+		})
+	}
+}
+
 func TestContextWindowForModel(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -121,6 +152,8 @@ func TestContextWindowForModel(t *testing.T) {
 		{"sonnet-46", "claude-sonnet-4-6", 1_000_000},
 		{"sonnet-uppercase", "CLAUDE-SONNET-4-6", 1_000_000},
 		{"sonnet-47-future", "claude-sonnet-4-7", 1_000_000},
+		// Sonnet 5.x：未來大版本，major >= 5 → 1M
+		{"sonnet-50-future-major", "claude-sonnet-5-0", 1_000_000},
 		// Sonnet 4.5 以下: 200K（官方規格）
 		{"sonnet-45", "claude-sonnet-4-5", 200_000},
 		{"sonnet-45-dated", "claude-sonnet-4-5-20250929", 200_000},
@@ -128,6 +161,8 @@ func TestContextWindowForModel(t *testing.T) {
 		{"opus-47", "claude-opus-4-7", 1_000_000},
 		{"opus-46", "claude-opus-4-6", 1_000_000},
 		{"opus-48-future", "claude-opus-4-8", 1_000_000},
+		// Opus 5.x：未來大版本，major >= 5 → 1M
+		{"opus-50-future-major", "claude-opus-5-0", 1_000_000},
 		// Opus 4.5 以下: 200K（官方規格）
 		{"opus-45", "claude-opus-4-5", 200_000},
 		{"opus-45-dated", "claude-opus-4-5-20251101", 200_000},

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -117,15 +117,17 @@ func TestContextWindowForModel(t *testing.T) {
 		{"haiku-base", "claude-haiku-4-5", 200_000},
 		{"haiku-dated-suffix", "claude-haiku-4-5-20251001", 200_000},
 		{"haiku-uppercase", "Claude-Haiku-4-5", 200_000},
-		// Sonnet 4.6+: 1M（官方規格）
+		// Sonnet 4.6+: 1M（官方規格，minor >= 6）
 		{"sonnet-46", "claude-sonnet-4-6", 1_000_000},
 		{"sonnet-uppercase", "CLAUDE-SONNET-4-6", 1_000_000},
+		{"sonnet-47-future", "claude-sonnet-4-7", 1_000_000},
 		// Sonnet 4.5 以下: 200K（官方規格）
 		{"sonnet-45", "claude-sonnet-4-5", 200_000},
 		{"sonnet-45-dated", "claude-sonnet-4-5-20250929", 200_000},
-		// Opus 4.6/4.7: 1M（官方規格）
+		// Opus 4.6+: 1M（官方規格，minor >= 6）
 		{"opus-47", "claude-opus-4-7", 1_000_000},
 		{"opus-46", "claude-opus-4-6", 1_000_000},
+		{"opus-48-future", "claude-opus-4-8", 1_000_000},
 		// Opus 4.5 以下: 200K（官方規格）
 		{"opus-45", "claude-opus-4-5", 200_000},
 		{"opus-45-dated", "claude-opus-4-5-20251101", 200_000},

--- a/pkg/cache/tracker_test.go
+++ b/pkg/cache/tracker_test.go
@@ -27,6 +27,7 @@ func TestCalculateNormal(t *testing.T) {
 	info := Calculate(lines)
 	if info == nil {
 		t.Fatal("expected non-nil CacheInfo")
+		return
 	}
 	if info.HitRate != 80 {
 		t.Errorf("expected HitRate=80, got %d", info.HitRate)
@@ -67,6 +68,7 @@ func TestCalculateSkipsSidechain(t *testing.T) {
 	info := Calculate(lines)
 	if info == nil {
 		t.Fatal("expected non-nil CacheInfo")
+		return
 	}
 	// 應該取得第一行（非 sidechain）的資料
 	if info.HitRate != 50 {
@@ -127,6 +129,7 @@ func TestCalculateAllCacheRead(t *testing.T) {
 	info := Calculate(lines)
 	if info == nil {
 		t.Fatal("expected non-nil CacheInfo")
+		return
 	}
 	if info.HitRate != 100 {
 		t.Errorf("expected HitRate=100, got %d", info.HitRate)
@@ -150,6 +153,7 @@ func TestCalculateNoCacheRead(t *testing.T) {
 	info := Calculate(lines)
 	if info == nil {
 		t.Fatal("expected non-nil CacheInfo")
+		return
 	}
 	if info.HitRate != 0 {
 		t.Errorf("expected HitRate=0, got %d", info.HitRate)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,18 +10,23 @@ func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.DisplayMode != "expanded" {
 		t.Fatalf("expected display_mode 'expanded', got %q", cfg.DisplayMode)
+		return
 	}
 	if cfg.OverflowMode != "wrap" {
 		t.Fatalf("expected overflow_mode 'wrap', got %q", cfg.OverflowMode)
+		return
 	}
 	if !cfg.Sections.Model {
 		t.Fatal("expected sections.model to be true by default")
+		return
 	}
 	if !cfg.Sections.Tools {
 		t.Fatal("expected sections.tools to be true by default")
+		return
 	}
 	if !cfg.Sections.APILimits {
 		t.Fatal("expected sections.api_limits to be true by default")
+		return
 	}
 }
 
@@ -29,9 +34,11 @@ func TestLoadMissingFile(t *testing.T) {
 	cfg := Load()
 	if cfg == nil {
 		t.Fatal("Load should return default config when file is missing")
+		return
 	}
 	if cfg.DisplayMode != "expanded" {
 		t.Fatalf("expected default display_mode, got %q", cfg.DisplayMode)
+		return
 	}
 }
 
@@ -44,23 +51,28 @@ func TestLoadCustomConfig(t *testing.T) {
 	configDir := filepath.Join(dir, ".claude", "omystatusline")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatal(err)
+		return
 	}
 
 	configJSON := `{"display_mode":"compact","sections":{"tools":false}}` // 刻意省略 overflow_mode
 	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0644); err != nil {
 		t.Fatal(err)
+		return
 	}
 
 	cfg := Load()
 	if cfg.DisplayMode != "compact" {
 		t.Fatalf("expected display_mode 'compact', got %q", cfg.DisplayMode)
+		return
 	}
 	if cfg.Sections.Tools {
 		t.Fatal("expected sections.tools to be false")
+		return
 	}
 	// overflow_mode 不在 JSON 中，應保持預設值 "wrap"
 	if cfg.OverflowMode != "wrap" {
 		t.Fatalf("expected overflow_mode 'wrap' when omitted from JSON, got %q", cfg.OverflowMode)
+		return
 	}
 }
 
@@ -71,19 +83,23 @@ func TestLoadOverflowModeTruncate(t *testing.T) {
 	configDir := filepath.Join(dir, ".claude", "omystatusline")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatal(err)
+		return
 	}
 
 	configJSON := `{"overflow_mode":"truncate"}`
 	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0644); err != nil {
 		t.Fatal(err)
+		return
 	}
 
 	cfg := Load()
 	if cfg.OverflowMode != "truncate" {
 		t.Fatalf("expected overflow_mode 'truncate', got %q", cfg.OverflowMode)
+		return
 	}
 	// 其他欄位應保持預設值
 	if cfg.DisplayMode != "expanded" {
 		t.Fatalf("expected default display_mode 'expanded', got %q", cfg.DisplayMode)
+		return
 	}
 }

--- a/pkg/context/autocompact_test.go
+++ b/pkg/context/autocompact_test.go
@@ -14,6 +14,7 @@ func TestDetectAutocompactNone(t *testing.T) {
 	result := DetectAutocompact(lines)
 	if result.Detected {
 		t.Fatal("expected no autocompact detected")
+		return
 	}
 }
 
@@ -26,9 +27,11 @@ func TestDetectAutocompactSummary(t *testing.T) {
 	result := DetectAutocompact(lines)
 	if !result.Detected {
 		t.Fatal("expected autocompact detected")
+		return
 	}
 	if result.Count != 2 {
 		t.Fatalf("expected count 2, got %d", result.Count)
+		return
 	}
 }
 
@@ -36,17 +39,20 @@ func TestFormatAutocompact(t *testing.T) {
 	// Not detected
 	if FormatAutocompact(&AutocompactInfo{}) != "" {
 		t.Fatal("expected empty for not detected")
+		return
 	}
 
 	// Single compression
 	result := FormatAutocompact(&AutocompactInfo{Detected: true, Count: 1})
 	if !strings.Contains(result, "⚠ compressed") {
 		t.Fatalf("expected compressed warning, got %q", result)
+		return
 	}
 
 	// Multiple compressions
 	result = FormatAutocompact(&AutocompactInfo{Detected: true, Count: 3})
 	if !strings.Contains(result, "×3") {
 		t.Fatalf("expected count in format, got %q", result)
+		return
 	}
 }

--- a/pkg/context/tracker_test.go
+++ b/pkg/context/tracker_test.go
@@ -24,6 +24,7 @@ func TestFormatNumber(t *testing.T) {
 		t.Run(fmt.Sprintf("num_%d", input), func(t *testing.T) {
 			if got := formatNumber(input); got != expected {
 				t.Fatalf("formatNumber(%d) = %q, want %q", input, got, expected)
+				return
 			}
 		})
 	}
@@ -32,12 +33,15 @@ func TestFormatNumber(t *testing.T) {
 func TestGetColor(t *testing.T) {
 	if color := getColor(40); color != statusline.ColorCtxGreen {
 		t.Fatalf("expected ColorCtxGreen for 40%%, got %q", color)
+		return
 	}
 	if color := getColor(70); color != statusline.ColorCtxGold {
 		t.Fatalf("expected ColorCtxGold for 70%%, got %q", color)
+		return
 	}
 	if color := getColor(90); color != statusline.ColorCtxRed {
 		t.Fatalf("expected ColorCtxRed for 90%%, got %q", color)
+		return
 	}
 }
 
@@ -49,6 +53,7 @@ func TestAnalyzeMaxTokens(t *testing.T) {
 	line := `{"message":{"usage":{"input_tokens":100000}},"isSidechain":false}`
 	if err := os.WriteFile(path, []byte(line), 0644); err != nil {
 		t.Fatalf("failed to write transcript: %v", err)
+		return
 	}
 
 	tests := []struct {
@@ -67,6 +72,7 @@ func TestAnalyzeMaxTokens(t *testing.T) {
 			result := Analyze(path, tt.maxTokens)
 			if !strings.Contains(result, tt.wantPct) {
 				t.Fatalf("Analyze with maxTokens=%d: expected %q in result, got %q", tt.maxTokens, tt.wantPct, result)
+				return
 			}
 		})
 	}
@@ -76,6 +82,7 @@ func TestAnalyzeEmptyPath(t *testing.T) {
 	result := Analyze("", 0)
 	if !strings.Contains(result, "0%") {
 		t.Fatalf("Analyze with empty path should show 0%%, got %q", result)
+		return
 	}
 }
 
@@ -123,6 +130,7 @@ func TestAnalyzeDetailedFromLines(t *testing.T) {
 	data := AnalyzeDetailedFromLines(lines, 200000)
 	if data == nil {
 		t.Fatal("expected non-nil ContextData")
+		return
 	}
 	if data.Tokens != 148027 {
 		t.Errorf("expected Tokens=148027, got %d", data.Tokens)
@@ -161,6 +169,7 @@ func TestAnalyzeDetailedFromLines_MetadataOnly(t *testing.T) {
 	data := AnalyzeDetailedFromLines(lines, 1_000_000)
 	if data == nil {
 		t.Fatal("expected non-nil ContextData")
+		return
 	}
 	if !data.NoUsageData {
 		t.Error("expected NoUsageData=true for metadata-only transcript")
@@ -253,6 +262,7 @@ func TestAnalyzeDetailedFromLines_NoUsageData_FalseForNewSession(t *testing.T) {
 	data := AnalyzeDetailedFromLines(nil, 200000)
 	if data == nil {
 		t.Fatal("expected non-nil ContextData")
+		return
 	}
 	if data.NoUsageData {
 		t.Error("expected NoUsageData=false for nil lines")
@@ -288,11 +298,13 @@ func TestAnalyzeDetailed_MetadataOnly(t *testing.T) {
 `
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("failed to write transcript: %v", err)
+		return
 	}
 
 	data := AnalyzeDetailed(path, 1_000_000)
 	if data == nil {
 		t.Fatal("expected non-nil ContextData")
+		return
 	}
 	if !data.NoUsageData {
 		t.Error("AnalyzeDetailed should set NoUsageData=true for metadata-only file")
@@ -307,6 +319,7 @@ func TestAnalyzeDetailed_UnreadablePath(t *testing.T) {
 	data := AnalyzeDetailed("/nonexistent/path.jsonl", 200000)
 	if data == nil {
 		t.Fatal("expected non-nil ContextData")
+		return
 	}
 	if data.NoUsageData {
 		t.Error("AnalyzeDetailed should not set NoUsageData for unreadable file")
@@ -319,6 +332,7 @@ func TestAnalyzeDetailed_EmptyPath(t *testing.T) {
 	data := AnalyzeDetailed("", 200000)
 	if data == nil {
 		t.Fatal("expected non-nil ContextData")
+		return
 	}
 	if data.NoUsageData {
 		t.Error("AnalyzeDetailed with empty path must not set NoUsageData")
@@ -357,6 +371,7 @@ func TestCalculateUsage(t *testing.T) {
 	}
 	if total := calculateUsageFromLines(lines); total != 175 {
 		t.Fatalf("expected total usage 175, got %d", total)
+		return
 	}
 }
 
@@ -501,6 +516,7 @@ func TestBuildFromTokens(t *testing.T) {
 		data := BuildFromTokens(tokens, 500_000)
 		if data == nil {
 			t.Fatal("expected non-nil ContextData")
+			return
 		}
 		if data.NoUsageData {
 			t.Error("BuildFromTokens must never set NoUsageData: usage came directly from Claude Code")
@@ -525,6 +541,7 @@ func TestBuildFromTokens(t *testing.T) {
 		data := BuildFromTokens(0, 200_000)
 		if data == nil {
 			t.Fatal("expected non-nil ContextData")
+			return
 		}
 		if data.NoUsageData {
 			t.Error("BuildFromTokens with tokens=0 must NOT set NoUsageData: it is a valid 0%, not metadata-only")
@@ -544,6 +561,7 @@ func TestBuildFromTokens(t *testing.T) {
 		data := BuildFromTokens(DefaultMaxTokens/2, 0)
 		if data == nil {
 			t.Fatal("expected non-nil ContextData")
+			return
 		}
 		if data.Percentage != 50 {
 			t.Errorf("Percentage = %d, want 50 (DefaultMaxTokens/2 out of DefaultMaxTokens)", data.Percentage)

--- a/pkg/git/branch_test.go
+++ b/pkg/git/branch_test.go
@@ -53,6 +53,7 @@ func TestGetBranch_MainRepoWithWorktreesDir(t *testing.T) {
 	worktreesDir := filepath.Join(tmpDir, ".worktrees")
 	if err := os.Mkdir(worktreesDir, 0755); err != nil {
 		t.Fatalf("Failed to create .worktrees dir: %v", err)
+		return
 	}
 
 	// 獲取分支資訊
@@ -90,6 +91,7 @@ func TestGetBranch_ActualWorktree(t *testing.T) {
 	testFile := filepath.Join(tmpDir, "README.md")
 	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
+		return
 	}
 	runGitCommand(t, tmpDir, "add", "README.md")
 	runGitCommand(t, tmpDir, "commit", "-m", "Initial commit")
@@ -277,5 +279,6 @@ func runGitCommand(t *testing.T, dir string, args ...string) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Git command failed: git %v\nError: %v\nOutput: %s", args, err, output)
+		return
 	}
 }

--- a/pkg/gitstatus/status_test.go
+++ b/pkg/gitstatus/status_test.go
@@ -10,6 +10,7 @@ func TestFormatEmpty(t *testing.T) {
 	result := Format(info)
 	if result != "" {
 		t.Fatalf("expected empty string for clean repo, got %q", result)
+		return
 	}
 }
 
@@ -18,12 +19,15 @@ func TestFormatDirty(t *testing.T) {
 	result := Format(info)
 	if !strings.Contains(result, "*") {
 		t.Fatalf("expected dirty indicator, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "!3") {
 		t.Fatalf("expected modified count, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "+1") {
 		t.Fatalf("expected added count, got %q", result)
+		return
 	}
 }
 
@@ -32,15 +36,18 @@ func TestFormatAheadBehind(t *testing.T) {
 	result := Format(info)
 	if !strings.Contains(result, "↑2") {
 		t.Fatalf("expected ahead indicator, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "↓1") {
 		t.Fatalf("expected behind indicator, got %q", result)
+		return
 	}
 }
 
 func TestFormatNil(t *testing.T) {
 	if Format(nil) != "" {
 		t.Fatal("expected empty for nil")
+		return
 	}
 }
 
@@ -57,17 +64,22 @@ func TestFormatFullStatus(t *testing.T) {
 	result := Format(info)
 	if !strings.Contains(result, "*") {
 		t.Fatalf("missing dirty, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "↑1") {
 		t.Fatalf("missing ahead, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "!2") {
 		t.Fatalf("missing modified, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "✘1") {
 		t.Fatalf("missing deleted, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "?3") {
 		t.Fatalf("missing untracked, got %q", result)
+		return
 	}
 }

--- a/pkg/speed/tracker_test.go
+++ b/pkg/speed/tracker_test.go
@@ -20,6 +20,7 @@ func TestExtractOutputTokens(t *testing.T) {
 	result := extractOutputTokens(lines)
 	if result != 500 {
 		t.Fatalf("expected 500, got %d", result)
+		return
 	}
 }
 
@@ -31,6 +32,7 @@ func TestExtractOutputTokensEmpty(t *testing.T) {
 	result := extractOutputTokens(lines)
 	if result != 0 {
 		t.Fatalf("expected 0, got %d", result)
+		return
 	}
 }
 
@@ -39,9 +41,11 @@ func TestFormat(t *testing.T) {
 	result := Format(info)
 	if result != "42 tok/s" {
 		t.Fatalf("expected '42 tok/s', got %q", result)
+		return
 	}
 
 	if Format(nil) != "" {
 		t.Fatal("expected empty string for nil")
+		return
 	}
 }

--- a/pkg/statusline/builder_test.go
+++ b/pkg/statusline/builder_test.go
@@ -27,14 +27,17 @@ func TestFormatModel(t *testing.T) {
 			if tt.wantPlain {
 				if result != tt.input {
 					t.Fatalf("FormatModel(%q) should return unchanged, got %q", tt.input, result)
+					return
 				}
 				return
 			}
 			if !strings.Contains(result, tt.wantColor) {
 				t.Fatalf("FormatModel(%q) should contain color %q, got %q", tt.input, tt.wantColor, result)
+				return
 			}
 			if !strings.HasSuffix(result, ColorReset) {
 				t.Fatalf("FormatModel(%q) should end with ColorReset, got %q", tt.input, result)
+				return
 			}
 		})
 	}
@@ -51,11 +54,13 @@ func TestIsSystemMessage(t *testing.T) {
 	for _, msg := range systemMessages {
 		if !isSystemMessage(msg) {
 			t.Fatalf("expected %q to be classified as system message", msg)
+			return
 		}
 	}
 
 	if isSystemMessage("normal user content") {
 		t.Fatal("expected regular content to be treated as user message")
+		return
 	}
 }
 
@@ -73,23 +78,28 @@ func TestFormatUserMessage(t *testing.T) {
 
 	if len(lines) != 4 {
 		t.Fatalf("expected 4 lines (3 content + ellipsis), got %d", len(lines))
+		return
 	}
 
 	if !strings.Contains(lines[0], strings.Repeat("A", 77)+"...") {
 		t.Fatalf("first line should be truncated with ellipsis, got %q", lines[0])
+		return
 	}
 
 	for i := 0; i < 3; i++ {
 		if !strings.HasPrefix(lines[i], fmt.Sprintf("%s｜%s", ColorReset, ColorGreen)) {
 			t.Fatalf("content line %d missing expected color prefix: %q", i, lines[i])
+			return
 		}
 		if !strings.HasSuffix(lines[i], ColorReset) {
 			t.Fatalf("content line %d missing color reset suffix: %q", i, lines[i])
+			return
 		}
 	}
 
 	if !strings.Contains(lines[3], "還有 1 行") {
 		t.Fatalf("ellipsis line should mention remaining content, got %q", lines[3])
+		return
 	}
 }
 
@@ -112,20 +122,25 @@ func TestFormatLinesChanged(t *testing.T) {
 			if tt.added == 0 && tt.removed == 0 {
 				if result != "" {
 					t.Fatalf("expected empty string for zero values, got %q", result)
+					return
 				}
 				return
 			}
 			if tt.added > 0 && !strings.Contains(result, fmt.Sprintf("+%d", tt.added)) {
 				t.Fatalf("expected +%d in result, got %q", tt.added, result)
+				return
 			}
 			if tt.removed > 0 && !strings.Contains(result, fmt.Sprintf("-%d", tt.removed)) {
 				t.Fatalf("expected -%d in result, got %q", tt.removed, result)
+				return
 			}
 			if tt.added > 0 && !strings.Contains(result, ColorGreen) {
 				t.Fatalf("expected green color for additions, got %q", result)
+				return
 			}
 			if tt.removed > 0 && !strings.Contains(result, ColorRed) {
 				t.Fatalf("expected red color for removals, got %q", result)
+				return
 			}
 		})
 	}
@@ -154,17 +169,21 @@ func TestFormatCacheDisplay(t *testing.T) {
 			if tt.wantEmpty {
 				if result != "" {
 					t.Fatalf("expected empty for %q, got %q", tt.cacheStr, result)
+					return
 				}
 				return
 			}
 			if !strings.Contains(result, tt.wantColor) {
 				t.Fatalf("expected color %q for hitRate %d, got %q", tt.wantColor, tt.hitRate, result)
+				return
 			}
 			if !strings.Contains(result, tt.cacheStr) {
 				t.Fatalf("expected %q in result, got %q", tt.cacheStr, result)
+				return
 			}
 			if !strings.HasSuffix(result, ColorReset) {
 				t.Fatalf("expected ColorReset suffix, got %q", result)
+				return
 			}
 		})
 	}
@@ -191,14 +210,17 @@ func TestFormatCostColored(t *testing.T) {
 			if tt.wantEmpty {
 				if result != "" {
 					t.Fatalf("expected empty for cost %.2f, got %q", tt.cost, result)
+					return
 				}
 				return
 			}
 			if !strings.Contains(result, tt.wantColor) {
 				t.Fatalf("expected color %q for cost %.2f, got %q", tt.wantColor, tt.cost, result)
+				return
 			}
 			if !strings.Contains(result, fmt.Sprintf("$%.2f", tt.cost)) {
 				t.Fatalf("expected formatted cost in result, got %q", result)
+				return
 			}
 		})
 	}

--- a/pkg/statusline/truncate_test.go
+++ b/pkg/statusline/truncate_test.go
@@ -117,6 +117,7 @@ func TestWrapLineWrapsToSecondLine(t *testing.T) {
 	lines := strings.Split(got, "\n")
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %q", len(lines), got)
+		return
 	}
 	if !strings.Contains(lines[0], "AAAAAAA") {
 		t.Errorf("line1 should contain AAAAAAA, got %q", lines[0])
@@ -144,6 +145,7 @@ func TestWrapLineStripsLeadingDivider(t *testing.T) {
 	lines := strings.Split(got, "\n")
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %q", len(lines), got)
+		return
 	}
 	// " | " 應被去掉，改為前綴 "↳ "
 	if strings.HasPrefix(lines[1], " | ") {
@@ -217,6 +219,7 @@ func TestWrapLineWithAnsiColors(t *testing.T) {
 	lines := strings.Split(got, "\n")
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines with ANSI segments, got %d: %q", len(lines), got)
+		return
 	}
 	if VisibleWidth(lines[0]) > 25 {
 		t.Errorf("line1 visible width %d exceeds maxWidth 25", VisibleWidth(lines[0]))

--- a/pkg/terminal/detect_test.go
+++ b/pkg/terminal/detect_test.go
@@ -9,6 +9,7 @@ func TestDetectASCIForced(t *testing.T) {
 
 	if mode := Detect(); mode != ModeASCII {
 		t.Fatalf("expected ModeASCII when CLAUDE_STATUSLINE_ASCII=1, got %d", mode)
+		return
 	}
 }
 
@@ -18,6 +19,7 @@ func TestDetectTrueColor(t *testing.T) {
 
 	if mode := Detect(); mode != ModeTrueColor {
 		t.Fatalf("expected ModeTrueColor for COLORTERM=truecolor, got %d", mode)
+		return
 	}
 }
 
@@ -27,6 +29,7 @@ func TestDetect24bit(t *testing.T) {
 
 	if mode := Detect(); mode != ModeTrueColor {
 		t.Fatalf("expected ModeTrueColor for COLORTERM=24bit, got %d", mode)
+		return
 	}
 }
 
@@ -37,6 +40,7 @@ func TestDetect256Color(t *testing.T) {
 
 	if mode := Detect(); mode != Mode256Color {
 		t.Fatalf("expected Mode256Color for TERM=xterm-256color, got %d", mode)
+		return
 	}
 }
 
@@ -47,5 +51,6 @@ func TestDetectDumbTerminal(t *testing.T) {
 
 	if mode := Detect(); mode != ModeASCII {
 		t.Fatalf("expected ModeASCII for TERM=dumb, got %d", mode)
+		return
 	}
 }

--- a/pkg/todo/parser_test.go
+++ b/pkg/todo/parser_test.go
@@ -14,6 +14,7 @@ func TestAnalyzeNoTodo(t *testing.T) {
 	result := Analyze(lines)
 	if result != nil {
 		t.Fatal("expected nil for no TodoWrite")
+		return
 	}
 }
 
@@ -42,18 +43,23 @@ func TestAnalyzeTodoInProgress(t *testing.T) {
 	result := Analyze(lines)
 	if result == nil {
 		t.Fatal("expected TodoInfo")
+		return
 	}
 	if result.Total != 3 {
 		t.Fatalf("expected 3 total, got %d", result.Total)
+		return
 	}
 	if result.Completed != 1 {
 		t.Fatalf("expected 1 completed, got %d", result.Completed)
+		return
 	}
 	if result.InProgressName != "Task B" {
 		t.Fatalf("expected in-progress 'Task B', got %q", result.InProgressName)
+		return
 	}
 	if result.AllComplete {
 		t.Fatal("expected AllComplete to be false")
+		return
 	}
 }
 
@@ -81,9 +87,11 @@ func TestAnalyzeTodoAllComplete(t *testing.T) {
 	result := Analyze(lines)
 	if result == nil {
 		t.Fatal("expected TodoInfo")
+		return
 	}
 	if !result.AllComplete {
 		t.Fatal("expected AllComplete to be true")
+		return
 	}
 }
 
@@ -93,9 +101,11 @@ func TestFormat(t *testing.T) {
 	result := Format(info)
 	if !strings.Contains(result, "▸ Build features") {
 		t.Fatalf("expected in-progress format, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "(2/5)") {
 		t.Fatalf("expected progress count, got %q", result)
+		return
 	}
 
 	// All complete
@@ -103,10 +113,12 @@ func TestFormat(t *testing.T) {
 	result = Format(info)
 	if !strings.Contains(result, "✓ All complete") {
 		t.Fatalf("expected all complete format, got %q", result)
+		return
 	}
 
 	// Nil
 	if Format(nil) != "" {
 		t.Fatal("expected empty string for nil")
+		return
 	}
 }

--- a/pkg/tools/tracker_test.go
+++ b/pkg/tools/tracker_test.go
@@ -14,6 +14,7 @@ func TestAnalyzeNoTools(t *testing.T) {
 	result := Analyze(lines)
 	if len(result) != 0 {
 		t.Fatalf("expected no tools, got %d", len(result))
+		return
 	}
 }
 
@@ -52,12 +53,15 @@ func TestAnalyzeActiveTools(t *testing.T) {
 	result := Analyze(lines)
 	if len(result) != 2 {
 		t.Fatalf("expected 2 active tools, got %d", len(result))
+		return
 	}
 	if result[0].Name != "Read" {
 		t.Fatalf("expected first tool 'Read', got %q", result[0].Name)
+		return
 	}
 	if result[1].Name != "Write" {
 		t.Fatalf("expected second tool 'Write', got %q", result[1].Name)
+		return
 	}
 }
 
@@ -92,6 +96,7 @@ func TestAnalyzeCompletedTool(t *testing.T) {
 	result := Analyze(lines)
 	if len(result) != 0 {
 		t.Fatalf("expected no active tools (tool completed), got %d", len(result))
+		return
 	}
 }
 
@@ -104,9 +109,11 @@ func TestFormat(t *testing.T) {
 	result := Format(tools)
 	if !strings.Contains(result, "◐ Read: /src/main.go") {
 		t.Fatalf("expected formatted tool with target, got %q", result)
+		return
 	}
 	if !strings.Contains(result, "◐ Write") {
 		t.Fatalf("expected formatted tool without target, got %q", result)
+		return
 	}
 }
 
@@ -115,5 +122,6 @@ func TestTruncatePath(t *testing.T) {
 	result := truncatePath(long, 30)
 	if len(result) > 30 {
 		t.Fatalf("expected truncated path <= 30 chars, got %d: %q", len(result), result)
+		return
 	}
 }

--- a/pkg/transcript/reader_test.go
+++ b/pkg/transcript/reader_test.go
@@ -19,25 +19,30 @@ func TestReadTail(t *testing.T) {
 	}
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644); err != nil {
 		t.Fatal(err)
+		return
 	}
 
 	result, err := ReadTail(path, 3)
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 
 	if len(result) != 3 {
 		t.Fatalf("expected 3 lines, got %d", len(result))
+		return
 	}
 
 	// 第一行是第 2 行（index 1）— "assistant" line
 	if result[0].Parsed == nil {
 		t.Fatal("expected second line to be valid JSON")
+		return
 	}
 
 	// 第二行不是有效 JSON
 	if result[1].Parsed != nil {
 		t.Fatal("expected 'not json line' to have nil Parsed")
+		return
 	}
 }
 
@@ -50,13 +55,16 @@ func TestReadAll(t *testing.T) {
 `
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
+		return
 	}
 	result, err := ReadAll(path)
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	if len(result) != 3 {
 		t.Fatalf("ReadAll: expected 3 lines, got %d", len(result))
+		return
 	}
 }
 
@@ -64,9 +72,11 @@ func TestReadTailEmptyPath(t *testing.T) {
 	result, err := ReadTail("", 10)
 	if err != nil {
 		t.Fatal("expected no error for empty path")
+		return
 	}
 	if result != nil {
 		t.Fatal("expected nil result for empty path")
+		return
 	}
 }
 
@@ -82,5 +92,6 @@ func TestFilterBySession(t *testing.T) {
 	result := FilterBySession(lines, "s1")
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines for session s1, got %d", len(result))
+		return
 	}
 }


### PR DESCRIPTION
## Summary

- Updates `contextWindowForModel()` fallback values from empirically-calibrated estimates (Sonnet 500K, Opus 800K) to official Anthropic specs
- Sonnet 4.6+, Opus 4.6/4.7 → 1M tokens; Haiku 4.5, Sonnet 4.5-, Opus 4.5- → 200K tokens; unknown non-empty model → conservative 200K
- Also fixes pre-existing SA5011 lint warnings across 13 test files (unreachable `return` after `t.Fatal()` in nil-check blocks)

**Note**: This fallback is rarely used in practice. Claude Code v2.0.25+ provides the accurate context window size directly via `input.ContextWindow.ContextWindowSize`. This fix only matters for older Claude Code versions or edge-case sessions where that field is absent.

**Bonus fix**: Discovered and fixed a subtle bug in the pre-commit/pre-push hooks where git-injected `GIT_DIR` environment variable was propagating into test subprocesses, causing `pkg/git` tests to fail silently when running from a worktree. Added `unset GIT_DIR GIT_WORK_TREE` before `make test` in both hooks.

## Test plan

- [x] `TestContextWindowForModel` — covers all model variants (haiku/sonnet/opus × old/new versions, unknown, empty)
- [x] `TestContextWindowMaxTokens` — verifies 1M is returned for sonnet-4-6 fallback path
- [x] Pre-commit hook passes in worktree context (root cause: `GIT_DIR` injection fixed)
- [x] All 12 packages pass: `go test -count=1 ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)