### PR TITLE
fix: correct worktree.original_cwd JSON field name (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+> Targets Claude Code statusline JSON schema **v2.1.90**.
+
+### Fixed
+- **Worktree `original_cwd` field name mismatch** (#29): `Input.Worktree` mapped
+  `OriginalRepoDir` to the JSON key `original_repo_dir`, but the official statusline
+  schema uses `original_cwd`. The field was therefore always empty. Renamed to
+  `OriginalCwd` (`original_cwd`) and added the previously missing
+  `OriginalBranch` (`original_branch`) field.
+- **`pkg/git` test isolation under git hooks**: `TestGetBranch_*` failed when run
+  inside a git hook (e.g. pre-commit) or CI that exports `GIT_DIR` / `GIT_WORK_TREE` /
+  `GIT_INDEX_FILE`. Those variables override `git -C <dir>`, redirecting queries on the
+  temp test repo to the real repo. Added a `TestMain` that unsets inherited `GIT_*`
+  variables before tests run.
+
 ## [2.1.0] - 2026-03-25
 
 ### Added

--- a/pkg/git/main_test.go
+++ b/pkg/git/main_test.go
@@ -1,0 +1,28 @@
+package git
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain 清除繼承自外部環境的 GIT_* 變數，確保測試隔離。
+//
+// 當測試在 git hook（例如 pre-commit）或某些 CI 環境下執行時，git 會 export
+// GIT_DIR、GIT_WORK_TREE、GIT_INDEX_FILE 等變數指向「正在 commit 的那個 repo」。
+// 這些變數的優先級高於 `git -C <dir>`，導致 GetBranch 對臨時測試 repo 的查詢
+// 被重導到真實 repo，回傳錯誤的分支名（測試會看到當前工作分支而非 test-branch）。
+//
+// 在所有測試開始前清掉這些變數，可讓 `git -C <tmpDir>` 真正作用於 tmpDir。
+func TestMain(m *testing.M) {
+	for _, key := range []string{
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_INDEX_FILE",
+		"GIT_COMMON_DIR",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_PREFIX",
+	} {
+		_ = os.Unsetenv(key)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/git/main_test.go
+++ b/pkg/git/main_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -12,17 +13,15 @@ import (
 // 這些變數的優先級高於 `git -C <dir>`，導致 GetBranch 對臨時測試 repo 的查詢
 // 被重導到真實 repo，回傳錯誤的分支名（測試會看到當前工作分支而非 test-branch）。
 //
-// 在所有測試開始前清掉這些變數，可讓 `git -C <tmpDir>` 真正作用於 tmpDir。
+// 在所有測試開始前清掉所有 GIT_* 變數，可讓 `git -C <tmpDir>` 真正作用於 tmpDir。
+// 用前綴比對（而非固定清單）以涵蓋任何會影響 repo discovery 的 GIT_* 變數，
+// 與 branch_test.go 的 runGitCommand 過濾子行程環境的方式保持一致。
 func TestMain(m *testing.M) {
-	for _, key := range []string{
-		"GIT_DIR",
-		"GIT_WORK_TREE",
-		"GIT_INDEX_FILE",
-		"GIT_COMMON_DIR",
-		"GIT_OBJECT_DIRECTORY",
-		"GIT_PREFIX",
-	} {
-		_ = os.Unsetenv(key)
+	for _, env := range os.Environ() {
+		key, _, _ := strings.Cut(env, "=")
+		if strings.HasPrefix(key, "GIT_") {
+			_ = os.Unsetenv(key)
+		}
 	}
 	os.Exit(m.Run())
 }

--- a/pkg/statusline/model.go
+++ b/pkg/statusline/model.go
@@ -52,10 +52,16 @@ type Input struct {
 	AgentID   string `json:"agent_id,omitempty"`
 	AgentType string `json:"agent_type,omitempty"`
 	Worktree  struct {
-		Name            string `json:"name,omitempty"`
-		Path            string `json:"path,omitempty"`
-		Branch          string `json:"branch,omitempty"`
-		OriginalRepoDir string `json:"original_repo_dir,omitempty"`
+		Name string `json:"name,omitempty"`
+		Path string `json:"path,omitempty"`
+		// Branch 為 worktree 目前所在的分支（對應官方 schema 的 "branch"）。
+		Branch string `json:"branch,omitempty"`
+		// OriginalCwd 為進入 worktree 前的原始工作目錄（官方 schema key 為 "original_cwd"）。
+		// 注意：舊版本曾誤用 "original_repo_dir"，但官方 statusline schema 從未提供該 key，
+		// 故 OriginalCwd 在修正前永遠為空字串。
+		OriginalCwd string `json:"original_cwd,omitempty"`
+		// OriginalBranch 為進入 worktree 前的原始分支（官方 schema 的 "original_branch"）。
+		OriginalBranch string `json:"original_branch,omitempty"`
 	} `json:"worktree,omitempty"`
 }
 

--- a/pkg/statusline/model_test.go
+++ b/pkg/statusline/model_test.go
@@ -1,0 +1,44 @@
+package statusline
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestInputWorktreeParsing 驗證 worktree 欄位能正確從官方 Claude Code statusline
+// schema 解析。此測試對應 #29：先前 OriginalCwd 誤用 "original_repo_dir" key，
+// 官方從未提供該 key，導致該欄位永遠為空字串。
+func TestInputWorktreeParsing(t *testing.T) {
+	// 取自官方 statusline JSON schema（worktree 區段）。
+	raw := `{
+		"worktree": {
+			"name": "my-feature",
+			"path": "/path/to/.claude/worktrees/my-feature",
+			"branch": "worktree-my-feature",
+			"original_cwd": "/path/to/project",
+			"original_branch": "main"
+		}
+	}`
+
+	var input Input
+	if err := json.Unmarshal([]byte(raw), &input); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Name", input.Worktree.Name, "my-feature"},
+		{"Path", input.Worktree.Path, "/path/to/.claude/worktrees/my-feature"},
+		{"Branch", input.Worktree.Branch, "worktree-my-feature"},
+		{"OriginalCwd", input.Worktree.OriginalCwd, "/path/to/project"},
+		{"OriginalBranch", input.Worktree.OriginalBranch, "main"},
+	}
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Errorf("Worktree.%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #29.

`Input.Worktree` mapped `OriginalRepoDir` to the JSON key `original_repo_dir`, but the official Claude Code statusline schema (v2.1.90) uses `original_cwd`. The field was therefore always empty at runtime, and `original_branch` was missing entirely.

## Changes

- Rename `OriginalRepoDir` → `OriginalCwd` (`json:"original_cwd"`).
- Add the previously missing `OriginalBranch` (`json:"original_branch"`).
- Add `TestInputWorktreeParsing` regression test that decodes the official schema's `worktree` block and asserts every field.
- Fix `pkg/git` test isolation: add a `TestMain` that unsets inherited `GIT_*` variables. `TestGetBranch_*` previously failed under git hooks / CI because git exports `GIT_DIR` (and friends) into the hook environment, which overrides `git -C <dir>` and redirected queries on the temp test repo to the real repo.
- Record both fixes in `CHANGELOG.md` under `[Unreleased]`, targeting schema v2.1.90.

## Test plan

- `make test` passes (including under the pre-commit hook, which previously failed on `TestGetBranch_*`).
- `make lint` and `gofmt -s` clean.
- New `TestInputWorktreeParsing` confirms `original_cwd` / `original_branch` now parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
