### PR TITLE
feat: read rate_limits from input JSON instead of OAuth API call (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Targets Claude Code statusline JSON schema **v2.1.90**.
 
+### Added
+- **Read `rate_limits` from input JSON** (#30): Claude Code v2.1.x+ provides API quota
+  usage directly in the statusline input (`rate_limits.five_hour` / `seven_day` with
+  `used_percentage` and `resets_at`). When present, the API limits section now uses this
+  data with zero network latency and works for all auth methods. The OAuth usage-API call
+  (`apilimits.Fetch()`, up to 2s timeout) is kept as a fallback for older Claude Code
+  versions that don't supply `rate_limits`. New `apilimits.FromRateLimits()` builds the
+  display info from the input data (percentages are 0-100, `resets_at` is a Unix epoch).
+
 ### Fixed
 - **Worktree `original_cwd` field name mismatch** (#29): `Input.Worktree` mapped
   `OriginalRepoDir` to the JSON key `original_repo_dir`, but the official statusline

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -263,7 +263,19 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			limitsInfo := apilimits.Fetch()
+			// 優先使用 input.RateLimits（Claude Code v2.1.x+ 直接提供，零網路延遲、
+			// 不限驗證方式）。ResetsAt > 0 代表此 feature 存在；否則 fallback 到
+			// OAuth usage API（較舊版本 Claude Code 不提供 rate_limits）。
+			rl := input.RateLimits
+			var limitsInfo *apilimits.APILimitsInfo
+			if rl.FiveHour.ResetsAt > 0 || rl.SevenDay.ResetsAt > 0 {
+				limitsInfo = apilimits.FromRateLimits(
+					rl.FiveHour.UsedPercentage, rl.FiveHour.ResetsAt,
+					rl.SevenDay.UsedPercentage, rl.SevenDay.ResetsAt,
+				)
+			} else {
+				limitsInfo = apilimits.Fetch()
+			}
 			results <- statusline.Result{Type: "api_limits", Data: apilimits.Format(limitsInfo)}
 		}()
 	}

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -270,8 +270,8 @@ func main() {
 			var limitsInfo *apilimits.APILimitsInfo
 			if rl.FiveHour.ResetsAt > 0 || rl.SevenDay.ResetsAt > 0 {
 				limitsInfo = apilimits.FromRateLimits(
-					rl.FiveHour.UsedPercentage, rl.FiveHour.ResetsAt,
-					rl.SevenDay.UsedPercentage, rl.SevenDay.ResetsAt,
+					apilimits.RateLimitWindow{UsedPercentage: rl.FiveHour.UsedPercentage, ResetsAtUnix: rl.FiveHour.ResetsAt},
+					apilimits.RateLimitWindow{UsedPercentage: rl.SevenDay.UsedPercentage, ResetsAtUnix: rl.SevenDay.ResetsAt},
 				)
 			} else {
 				limitsInfo = apilimits.Fetch()

--- a/pkg/apilimits/client.go
+++ b/pkg/apilimits/client.go
@@ -135,16 +135,24 @@ func fetchFromAPI(token string) *APILimitsInfo {
 	return info
 }
 
+// RateLimitWindow 為單一配額窗口（5h 或 7d）的使用量輸入。
+// 用具名欄位的 struct（而非 positional scalar）避免 call site 誤置百分比與重置時間。
+type RateLimitWindow struct {
+	// UsedPercentage 已是 0-100 的百分比（非 OAuth 的 0-1 分數）。
+	UsedPercentage float64
+	// ResetsAtUnix 為重置時間的 Unix epoch 秒（非 OAuth 的 RFC3339 字串）。
+	ResetsAtUnix int64
+}
+
 // FromRateLimits 由 Claude Code 直接提供的 rate_limits 資料建構 APILimitsInfo，
-// 免去向 OAuth usage API 發 HTTP 請求。與 fetchFromAPI 不同：
-//   - 百分比已是 0-100（OAuth 的 Utilization 是 0-1 需 ×100）
-//   - 重置時間為 Unix epoch 秒（OAuth 是 RFC3339 字串）
-func FromRateLimits(fiveHourPct float64, fiveHourReset int64, sevenDayPct float64, sevenDayReset int64) *APILimitsInfo {
+// 免去向 OAuth usage API 發 HTTP 請求。與 fetchFromAPI 不同：百分比已是 0-100、
+// 重置時間為 Unix epoch 秒（語意見 RateLimitWindow）。
+func FromRateLimits(fiveHour, sevenDay RateLimitWindow) *APILimitsInfo {
 	info := &APILimitsInfo{
-		FiveHourPct:   int(fiveHourPct),
-		SevenDayPct:   int(sevenDayPct),
-		FiveHourReset: formatResetUnix(fiveHourReset),
-		SevenDayReset: formatResetUnix(sevenDayReset),
+		FiveHourPct:   int(fiveHour.UsedPercentage),
+		SevenDayPct:   int(sevenDay.UsedPercentage),
+		FiveHourReset: formatResetUnix(fiveHour.ResetsAtUnix),
+		SevenDayReset: formatResetUnix(sevenDay.ResetsAtUnix),
 	}
 	if info.FiveHourPct >= 100 || info.SevenDayPct >= 100 {
 		info.LimitReached = true

--- a/pkg/apilimits/client.go
+++ b/pkg/apilimits/client.go
@@ -135,6 +135,24 @@ func fetchFromAPI(token string) *APILimitsInfo {
 	return info
 }
 
+// FromRateLimits 由 Claude Code 直接提供的 rate_limits 資料建構 APILimitsInfo，
+// 免去向 OAuth usage API 發 HTTP 請求。與 fetchFromAPI 不同：
+//   - 百分比已是 0-100（OAuth 的 Utilization 是 0-1 需 ×100）
+//   - 重置時間為 Unix epoch 秒（OAuth 是 RFC3339 字串）
+func FromRateLimits(fiveHourPct float64, fiveHourReset int64, sevenDayPct float64, sevenDayReset int64) *APILimitsInfo {
+	info := &APILimitsInfo{
+		FiveHourPct:   int(fiveHourPct),
+		SevenDayPct:   int(sevenDayPct),
+		FiveHourReset: formatResetUnix(fiveHourReset),
+		SevenDayReset: formatResetUnix(sevenDayReset),
+	}
+	if info.FiveHourPct >= 100 || info.SevenDayPct >= 100 {
+		info.LimitReached = true
+	}
+	return info
+}
+
+// formatResetTime 解析 OAuth API 的 RFC3339 重置時間並格式化為剩餘時間。
 func formatResetTime(resetsAt string) string {
 	if resetsAt == "" {
 		return ""
@@ -145,6 +163,19 @@ func formatResetTime(resetsAt string) string {
 		return ""
 	}
 
+	return formatRemaining(t)
+}
+
+// formatResetUnix 將 Unix epoch 秒的重置時間格式化為剩餘時間。
+func formatResetUnix(epoch int64) string {
+	if epoch <= 0 {
+		return ""
+	}
+	return formatRemaining(time.Unix(epoch, 0))
+}
+
+// formatRemaining 將目標時間轉為人類可讀的剩餘時間（如 45m / 2h30m / 3d）。
+func formatRemaining(t time.Time) string {
 	remaining := time.Until(t)
 	if remaining <= 0 {
 		return "now"

--- a/pkg/apilimits/client_test.go
+++ b/pkg/apilimits/client_test.go
@@ -1,0 +1,102 @@
+package apilimits
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// 說明：formatRemaining 用 time.Until(t)，實際剩餘時間會比設定的 offset 少數微秒，
+// int() 截斷會把「正好 2h」變成「1h59m」。因此測試一律加 30s buffer，
+// 讓截斷後的整數落在預期值（30s 遠小於分鐘解析度，但足以蓋過微秒誤差）。
+const tinyBuffer = 30 * time.Second
+
+func TestFromRateLimits(t *testing.T) {
+	now := time.Now()
+	fiveHourReset := now.Add(2*time.Hour + tinyBuffer).Unix()
+	sevenDayReset := now.Add(48*time.Hour + tinyBuffer).Unix()
+
+	info := FromRateLimits(23.5, fiveHourReset, 41.2, sevenDayReset)
+	if info == nil {
+		t.Fatal("FromRateLimits returned nil")
+	}
+
+	// used_percentage 已是 0-100，直接取整數（不像 OAuth 的 0-1 需 ×100）。
+	if info.FiveHourPct != 23 {
+		t.Errorf("FiveHourPct = %d, want 23", info.FiveHourPct)
+	}
+	if info.SevenDayPct != 41 {
+		t.Errorf("SevenDayPct = %d, want 41", info.SevenDayPct)
+	}
+	if info.FiveHourReset != "2h" {
+		t.Errorf("FiveHourReset = %q, want \"2h\"", info.FiveHourReset)
+	}
+	if info.SevenDayReset != "2d" {
+		t.Errorf("SevenDayReset = %q, want \"2d\"", info.SevenDayReset)
+	}
+	if info.LimitReached {
+		t.Error("LimitReached should be false for sub-100% usage")
+	}
+}
+
+func TestFromRateLimitsLimitReached(t *testing.T) {
+	reset := time.Now().Add(time.Hour + tinyBuffer).Unix()
+	info := FromRateLimits(100, reset, 50, reset)
+	if !info.LimitReached {
+		t.Error("LimitReached should be true when a window hits 100%")
+	}
+}
+
+func TestFromRateLimitsZeroUsage(t *testing.T) {
+	// 0% 使用但有 resets_at：合法狀態（session 剛開始），不應視為缺資料。
+	reset := time.Now().Add(time.Hour + tinyBuffer).Unix()
+	info := FromRateLimits(0, reset, 0, reset)
+	if info.FiveHourPct != 0 || info.SevenDayPct != 0 {
+		t.Errorf("expected 0%% usage, got 5h=%d 7d=%d", info.FiveHourPct, info.SevenDayPct)
+	}
+	if info.FiveHourReset == "" {
+		t.Error("FiveHourReset should be populated when resets_at > 0")
+	}
+}
+
+func TestFormatResetUnix(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name  string
+		epoch int64
+		want  string
+	}{
+		{"zero epoch yields empty", 0, ""},
+		{"negative epoch yields empty", -1, ""},
+		{"past time yields now", now.Add(-time.Hour).Unix(), "now"},
+		{"45 minutes ahead", now.Add(45*time.Minute + tinyBuffer).Unix(), "45m"},
+		{"2h30m ahead", now.Add(2*time.Hour + 30*time.Minute + tinyBuffer).Unix(), "2h30m"},
+		{"3 days ahead", now.Add(72*time.Hour + tinyBuffer).Unix(), "3d"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatResetUnix(tc.epoch)
+			if got != tc.want {
+				t.Errorf("formatResetUnix(%d) = %q, want %q", tc.epoch, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatFromRateLimits(t *testing.T) {
+	reset := time.Now().Add(3*time.Hour + tinyBuffer).Unix()
+	info := FromRateLimits(25, reset, 40, reset)
+	out := Format(info)
+
+	for _, want := range []string{"5h: 25%", "7d: 40%"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Format output %q missing %q", out, want)
+		}
+	}
+}
+
+func TestFormatNil(t *testing.T) {
+	if got := Format(nil); got != "" {
+		t.Errorf("Format(nil) = %q, want empty", got)
+	}
+}

--- a/pkg/apilimits/client_test.go
+++ b/pkg/apilimits/client_test.go
@@ -16,7 +16,10 @@ func TestFromRateLimits(t *testing.T) {
 	fiveHourReset := now.Add(2*time.Hour + tinyBuffer).Unix()
 	sevenDayReset := now.Add(48*time.Hour + tinyBuffer).Unix()
 
-	info := FromRateLimits(23.5, fiveHourReset, 41.2, sevenDayReset)
+	info := FromRateLimits(
+		RateLimitWindow{UsedPercentage: 23.5, ResetsAtUnix: fiveHourReset},
+		RateLimitWindow{UsedPercentage: 41.2, ResetsAtUnix: sevenDayReset},
+	)
 	if info == nil {
 		t.Fatal("FromRateLimits returned nil")
 	}
@@ -41,7 +44,10 @@ func TestFromRateLimits(t *testing.T) {
 
 func TestFromRateLimitsLimitReached(t *testing.T) {
 	reset := time.Now().Add(time.Hour + tinyBuffer).Unix()
-	info := FromRateLimits(100, reset, 50, reset)
+	info := FromRateLimits(
+		RateLimitWindow{UsedPercentage: 100, ResetsAtUnix: reset},
+		RateLimitWindow{UsedPercentage: 50, ResetsAtUnix: reset},
+	)
 	if !info.LimitReached {
 		t.Error("LimitReached should be true when a window hits 100%")
 	}
@@ -50,7 +56,10 @@ func TestFromRateLimitsLimitReached(t *testing.T) {
 func TestFromRateLimitsZeroUsage(t *testing.T) {
 	// 0% 使用但有 resets_at：合法狀態（session 剛開始），不應視為缺資料。
 	reset := time.Now().Add(time.Hour + tinyBuffer).Unix()
-	info := FromRateLimits(0, reset, 0, reset)
+	info := FromRateLimits(
+		RateLimitWindow{UsedPercentage: 0, ResetsAtUnix: reset},
+		RateLimitWindow{UsedPercentage: 0, ResetsAtUnix: reset},
+	)
 	if info.FiveHourPct != 0 || info.SevenDayPct != 0 {
 		t.Errorf("expected 0%% usage, got 5h=%d 7d=%d", info.FiveHourPct, info.SevenDayPct)
 	}
@@ -85,7 +94,10 @@ func TestFormatResetUnix(t *testing.T) {
 
 func TestFormatFromRateLimits(t *testing.T) {
 	reset := time.Now().Add(3*time.Hour + tinyBuffer).Unix()
-	info := FromRateLimits(25, reset, 40, reset)
+	info := FromRateLimits(
+		RateLimitWindow{UsedPercentage: 25, ResetsAtUnix: reset},
+		RateLimitWindow{UsedPercentage: 40, ResetsAtUnix: reset},
+	)
 	out := Format(info)
 
 	for _, want := range []string{"5h: 25%", "7d: 40%"} {

--- a/pkg/statusline/model.go
+++ b/pkg/statusline/model.go
@@ -63,6 +63,21 @@ type Input struct {
 		// OriginalBranch 為進入 worktree 前的原始分支（官方 schema 的 "original_branch"）。
 		OriginalBranch string `json:"original_branch,omitempty"`
 	} `json:"worktree,omitempty"`
+	// RateLimits 為 Claude Code v2.1.x+ 直接提供的 API 配額使用量。
+	// 存在時可直接顯示，免去向 OAuth usage API 發 HTTP 請求（見 pkg/apilimits）。
+	// 欄位語意與 OAuth API 不同：UsedPercentage 已是 0-100 的百分比（非 0-1 分數），
+	// ResetsAt 為 Unix epoch 秒（非 RFC3339 字串）。
+	// 判斷是否提供此資料：ResetsAt > 0（feature 存在時一定有重置時間）。
+	RateLimits struct {
+		FiveHour struct {
+			UsedPercentage float64 `json:"used_percentage,omitempty"`
+			ResetsAt       int64   `json:"resets_at,omitempty"`
+		} `json:"five_hour,omitempty"`
+		SevenDay struct {
+			UsedPercentage float64 `json:"used_percentage,omitempty"`
+			ResetsAt       int64   `json:"resets_at,omitempty"`
+		} `json:"seven_day,omitempty"`
+	} `json:"rate_limits,omitempty"`
 }
 
 // 結果通道資料

--- a/pkg/statusline/model_test.go
+++ b/pkg/statusline/model_test.go
@@ -42,3 +42,39 @@ func TestInputWorktreeParsing(t *testing.T) {
 		}
 	}
 }
+
+// TestInputRateLimitsParsing 驗證 rate_limits 欄位能正確從官方 Claude Code statusline
+// schema 解析。此測試對應 #30：used_percentage 為 0-100 浮點，resets_at 為 Unix epoch。
+func TestInputRateLimitsParsing(t *testing.T) {
+	// 取自官方 statusline JSON schema（rate_limits 區段）。
+	raw := `{
+		"rate_limits": {
+			"five_hour": {
+				"used_percentage": 23.5,
+				"resets_at": 1738425600
+			},
+			"seven_day": {
+				"used_percentage": 41.2,
+				"resets_at": 1738857600
+			}
+		}
+	}`
+
+	var input Input
+	if err := json.Unmarshal([]byte(raw), &input); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if got := input.RateLimits.FiveHour.UsedPercentage; got != 23.5 {
+		t.Errorf("FiveHour.UsedPercentage = %v, want 23.5", got)
+	}
+	if got := input.RateLimits.FiveHour.ResetsAt; got != 1738425600 {
+		t.Errorf("FiveHour.ResetsAt = %d, want 1738425600", got)
+	}
+	if got := input.RateLimits.SevenDay.UsedPercentage; got != 41.2 {
+		t.Errorf("SevenDay.UsedPercentage = %v, want 41.2", got)
+	}
+	if got := input.RateLimits.SevenDay.ResetsAt; got != 1738857600 {
+		t.Errorf("SevenDay.ResetsAt = %d, want 1738857600", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #30. Builds on #29 (merged).

Claude Code v2.1.x+ provides API quota usage directly in the statusline input via `rate_limits`. This PR reads that data instead of calling the OAuth usage API on every render.

## Changes

- Add `Input.RateLimits` struct (`five_hour` / `seven_day`, each with `used_percentage` 0-100 float and `resets_at` Unix epoch) — matching the official schema v2.1.90.
- Add `apilimits.FromRateLimits()` to build `APILimitsInfo` from the input data. Note the semantic differences from the OAuth path: percentages are already 0-100 (OAuth `utilization` is 0-1 ×100), and `resets_at` is a Unix epoch (OAuth is RFC3339).
- Refactor reset-time formatting: shared `formatRemaining(time.Time)`, with `formatResetUnix(int64)` for epoch input and the existing `formatResetTime(string)` for RFC3339.
- `cmd/statusline/main.go` prefers `input.RateLimits` when `resets_at > 0`; falls back to `apilimits.Fetch()` for older Claude Code versions that don't supply `rate_limits`.
- Add `pkg/apilimits` tests (previously none) and a `rate_limits` JSON parsing regression test in `pkg/statusline`.

## Benefits

- Zero network latency for the API-limits section on v2.1.x+ (no up-to-2s OAuth timeout on the hot path).
- Works for all auth methods, not just OAuth.

## Test plan

- `make test` passes (incl. under the pre-commit hook).
- `make lint` clean (gofmt + golangci-lint, 0 issues).
- New tests cover `FromRateLimits` percentage/limit-reached/zero-usage cases, `formatResetUnix` boundaries, and JSON parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
