### PR TITLE
feat: use input.session_name directly instead of transcript parsing (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`apilimits.Fetch()`, up to 2s timeout) is kept as a fallback for older Claude Code
   versions that don't supply `rate_limits`. New `apilimits.FromRateLimits()` builds the
   display info from the input data (percentages are 0-100, `resets_at` is a Unix epoch).
+- **Read `session_name` from input JSON** (#31): Claude Code v2.1.x+ provides the session
+  name (set via `/rename`) as a top-level `session_name` field. The session-name section
+  now prefers it over scanning the transcript (`ExtractSessionName`), removing one
+  transcript scan from the hot path and working correctly for worktree sessions whose
+  transcript is metadata-only. Falls back to transcript parsing when the field is absent.
 
 ### Fixed
 - **Worktree `original_cwd` field name mismatch** (#29): `Input.Worktree` mapped

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -216,6 +216,13 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// 優先使用 input.SessionName（Claude Code v2.1.x+ 直接提供，零 transcript 掃描，
+			// worktree 的 metadata-only transcript 也有效）。缺此欄位時 fallback 到掃描
+			// transcript（較舊版本 Claude Code）。
+			if input.SessionName != "" {
+				results <- statusline.Result{Type: "session_name", Data: input.SessionName}
+				return
+			}
 			if lines == nil {
 				results <- statusline.Result{Type: "session_name", Data: ""}
 				return

--- a/pkg/statusline/model.go
+++ b/pkg/statusline/model.go
@@ -2,8 +2,12 @@ package statusline
 
 // 輸入資料結構 - 支援 Claude Code v2.0.25+ 的新 JSON 格式
 type Input struct {
-	HookEventName  string `json:"hook_event_name,omitempty"` // v2.0.25+ 新增
-	SessionID      string `json:"session_id"`
+	HookEventName string `json:"hook_event_name,omitempty"` // v2.0.25+ 新增
+	SessionID     string `json:"session_id"`
+	// SessionName 為 Claude Code v2.1.x+ 直接提供的 session 名稱（由 /rename 設定）。
+	// 存在時優先使用，免去掃描 transcript（ExtractSessionName）；worktree session 的
+	// metadata-only transcript 也能正確取得。
+	SessionName    string `json:"session_name,omitempty"`
 	TranscriptPath string `json:"transcript_path,omitempty"`
 	Cwd            string `json:"cwd,omitempty"` // v2.0.25+ 新增
 	Model          struct {

--- a/pkg/statusline/model_test.go
+++ b/pkg/statusline/model_test.go
@@ -78,3 +78,30 @@ func TestInputRateLimitsParsing(t *testing.T) {
 		t.Errorf("SevenDay.ResetsAt = %d, want 1738857600", got)
 	}
 }
+
+// TestInputSessionNameParsing 驗證 top-level session_name 欄位能正確解析。
+// 此測試對應 #31：優先使用 input.session_name，免去掃描 transcript。
+func TestInputSessionNameParsing(t *testing.T) {
+	raw := `{"session_id":"abc123","session_name":"my-session"}`
+
+	var input Input
+	if err := json.Unmarshal([]byte(raw), &input); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if input.SessionName != "my-session" {
+		t.Errorf("SessionName = %q, want %q", input.SessionName, "my-session")
+	}
+	if input.SessionID != "abc123" {
+		t.Errorf("SessionID = %q, want %q", input.SessionID, "abc123")
+	}
+
+	// 缺 session_name 時應為空字串（觸發 fallback 到 transcript 掃描）。
+	var empty Input
+	if err := json.Unmarshal([]byte(`{"session_id":"x"}`), &empty); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if empty.SessionName != "" {
+		t.Errorf("missing session_name should be empty, got %q", empty.SessionName)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #31. Builds on #29 and #30 (merged).

Claude Code v2.1.x+ provides the session name (set via `/rename`) as a top-level `session_name` field in the statusline input. This PR reads it directly instead of scanning the transcript.

## Changes

- Add top-level `Input.SessionName` (`json:"session_name"`).
- `cmd/statusline/main.go` prefers `input.SessionName` when non-empty; falls back to `statusline.ExtractSessionName(lines, ...)` for older Claude Code versions that don't supply the field.
- Add a `session_name` JSON parsing regression test covering both the present and absent (fallback) cases.

## Benefits

- Removes one transcript scan from the hot path on v2.1.x+.
- Session name is correct even for worktree sessions whose transcript is metadata-only (the transcript-scan path returned empty there).

## Test plan

- `make test` passes (incl. under the pre-commit hook).
- `make lint` clean (gofmt + golangci-lint, 0 issues).
- New `TestInputSessionNameParsing` asserts the field parses when present and is empty when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
