### PR TITLE
fix: context window stuck at 100% for Fable 5 and [1m] sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Build
       run: go build -v -o statusline-go ./cmd/statusline
 
+    - name: Run tests
+      run: go test -count=1 ./...
+
     - name: Run go vet
       run: go vet ./...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,12 +101,17 @@ Formatted status line output to stdout
 - Analyzes transcript to estimate token count
 - `AnalyzeDetailedFromLines(lines, maxTokens)` - returns `ContextData` with bar, info, percentage
 - `InferModelFromLines(lines)` - reads `message.model` from last usage entry; used for mixed-model sessions
-- `maxTokens` (denominator) source of truth: transcript `message.model` → `input.Model.ID` → `contextWindowForModel()`; `STATUSLINE_MAX_TOKENS` env var is an **unconditional override** (not a fallback — it overrides after model inference)
+- `maxTokens` (denominator) resolution chain (`resolveMaxTokens()`, `cmd/statusline/main.go`; later layers override earlier):
+  1. Model inference: transcript `message.model` (preferred for mixed-model sessions) → `input.Model.ID` fallback → `contextWindowForModel()`
+  2. `[1m]` marker on `input.Model.ID` forces 1M — transcript model IDs never carry the suffix, so inference alone underestimates 1M-beta sessions
+  3. `STATUSLINE_MAX_TOKENS` env var is the **unconditional final override**
   - **`input.ContextWindow.ContextWindowSize` is NOT used as denominator** — Claude Code sends the current token count there, not the model's max capacity; using it as denominator causes ~100% always
   - Token count (numerator) uses `input.ContextWindow.CurrentUsage` when available (more accurate than transcript); falls back to transcript parsing
 - Model context window mapping (in `contextWindowForModel()`, `cmd/statusline/main.go`; **official Anthropic specs**):
-  - Haiku: 200K | Sonnet/Opus major ≥ 5 OR (major==4 AND minor ≥ 6): 1M | others: 200K | unknown non-empty: 200K | empty: `DefaultMaxTokens`
-  - Version parsed via `claudeModelVersion()`: scans from end for two consecutive small integers (< 100), ignores date suffixes
+  - ID containing `[1m]`: 1M (takes precedence over family/version rules)
+  - Haiku: 200K | Sonnet/Opus/Fable major ≥ 5 OR (major==4 AND minor ≥ 6): 1M | others: 200K
+  - Unknown non-empty families apply the same version rule (major ≥ 5 → 1M); otherwise 200K with a stderr warning | empty: `DefaultMaxTokens`
+  - Version parsed via `claudeModelVersion()`: scans from end for two consecutive small integers (< 100), ignores date suffixes; single-version IDs (e.g. `claude-fable-5`) fall back to `{major}.0`
 - Generates visual progress bar (██████░░░░ format)
 - Color-coded warnings: green (<60%), gold (60-80%), red (≥80%)
 

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -25,7 +25,18 @@ import (
 	"github.com/howie/claude-code-omystatusline/pkg/transcript"
 )
 
-const maxTokensSourceModelInference = "model-inference"
+// maxTokens 來源標籤（STATUSLINE_DEBUG 輸出用），對應 resolveMaxTokens 的三層優先順序。
+const (
+	maxTokensSourceModelInference = "model-inference"
+	maxTokensSourceInput1MMarker  = "input-1m-marker"
+	maxTokensSourceEnvOverride    = "env-override"
+)
+
+// context window 容量（官方 Anthropic 規格）。
+const (
+	contextWindow1M   = 1_000_000
+	contextWindow200K = 200_000
+)
 
 func main() {
 	var input statusline.Input
@@ -64,24 +75,7 @@ func main() {
 	if effectiveModelID == "" {
 		effectiveModelID = input.Model.ID
 	}
-	maxTokens := contextWindowForModel(effectiveModelID)
-	// transcript 內的 message.model 不帶 "[1m]" 後綴，推斷結果可能低估分母；
-	// input.Model.ID 帶 1M 標記時直接採信（session 層級的 context window 是 1M）。
-	if strings.Contains(strings.ToLower(input.Model.ID), "[1m]") {
-		maxTokens = 1_000_000
-	}
-	maxTokensSource := maxTokensSourceModelInference
-	if envMax := os.Getenv("STATUSLINE_MAX_TOKENS"); envMax != "" {
-		v, err := strconv.Atoi(envMax)
-		switch {
-		case err != nil:
-			fmt.Fprintf(os.Stderr, "statusline: STATUSLINE_MAX_TOKENS=%q is not a valid integer, using model default\n", envMax)
-		case v <= 0:
-			fmt.Fprintf(os.Stderr, "statusline: STATUSLINE_MAX_TOKENS=%d must be > 0, using model default\n", v)
-		default:
-			maxTokens = v
-		}
-	}
+	maxTokens, maxTokensSource := resolveMaxTokens(effectiveModelID, input.Model.ID, os.Getenv("STATUSLINE_MAX_TOKENS"))
 
 	// Phase 3: 並行處理所有資料收集
 	results := make(chan statusline.Result, 14)
@@ -518,27 +512,63 @@ func formatSegments(segments []statusline.Segment, maxWidth int, overflowMode st
 	}
 }
 
+// resolveMaxTokens 決定 context 百分比的分母與其來源標籤（STATUSLINE_DEBUG 用）。
+// 優先順序（後者覆蓋前者）：
+//  1. effectiveModelID（transcript 推斷優先）的家族/版本推斷
+//  2. inputModelID 的 "[1m]" 標記 — transcript 的 message.model 從不帶此後綴，
+//     1M beta session 只靠推斷會低估分母。刻意取捨：mixed-model session（input 為
+//     sonnet[1m] 但 transcript 最後是 opus 200K）以 session 主模型的 1M 為準。
+//  3. STATUSLINE_MAX_TOKENS env var — 文件化的無條件 override。
+func resolveMaxTokens(effectiveModelID, inputModelID, envMax string) (int, string) {
+	maxTokens := contextWindowForModel(effectiveModelID)
+	source := maxTokensSourceModelInference
+	if strings.Contains(strings.ToLower(inputModelID), "[1m]") {
+		maxTokens = contextWindow1M
+		source = maxTokensSourceInput1MMarker
+	}
+	if envMax != "" {
+		v, err := strconv.Atoi(envMax)
+		switch {
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "statusline: STATUSLINE_MAX_TOKENS=%q is not a valid integer, using model default\n", envMax)
+		case v <= 0:
+			fmt.Fprintf(os.Stderr, "statusline: STATUSLINE_MAX_TOKENS=%d must be > 0, using model default\n", v)
+		default:
+			maxTokens = v
+			source = maxTokensSourceEnvOverride
+		}
+	}
+	return maxTokens, source
+}
+
 // contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens）。
+// ID 含 "[1m]" 標記時無條件回傳 1M（優先於下列家族/版本規則）。
 // 依官方 Anthropic 規格：Sonnet/Opus/Fable major >= 5，或 major == 4 且 minor >= 6 時為 1M；其餘為 200K。
+// 未知家族亦套用相同版本規則，避免下一個新家族重演 fable 落入 200K fallback 的 regression。
 // 此函式永遠是百分比的分母（denominator）；ContextWindowSize 不可用作分母（見 hasContextWindow 上方注解）。
 func contextWindowForModel(modelID string) int {
 	id := strings.ToLower(modelID)
 	// "[1m]" 是 Claude Code 對 1M context session 的明確標記（如 claude-fable-5[1m]），
 	// 比家族/版本推斷更可靠，優先採信。
 	if strings.Contains(id, "[1m]") {
-		return 1_000_000
+		return contextWindow1M
 	}
 	switch {
 	case strings.Contains(id, "haiku"):
-		return 200_000 // Haiku 從未超過 200K；如有更大版本請重新評估
+		return contextWindow200K // Haiku 從未超過 200K；如有更大版本請重新評估
 	case strings.Contains(id, "sonnet"), strings.Contains(id, "opus"), strings.Contains(id, "fable"):
 		if claudeModelIs1M(id) {
-			return 1_000_000
+			return contextWindow1M
 		}
-		return 200_000
+		return contextWindow200K
 	case id != "":
+		// 未知家族也套用版本規則：major >= 5 的新家族（如未來的 claude-nova-5）
+		// 視為 1M，不再無條件 200K。
+		if claudeModelIs1M(id) {
+			return contextWindow1M
+		}
 		fmt.Fprintf(os.Stderr, "statusline: unknown model %q, using 200K context window fallback\n", modelID)
-		return 200_000
+		return contextWindow200K
 	default:
 		return context.DefaultMaxTokens
 	}

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -65,6 +65,11 @@ func main() {
 		effectiveModelID = input.Model.ID
 	}
 	maxTokens := contextWindowForModel(effectiveModelID)
+	// transcript 內的 message.model 不帶 "[1m]" 後綴，推斷結果可能低估分母；
+	// input.Model.ID 帶 1M 標記時直接採信（session 層級的 context window 是 1M）。
+	if strings.Contains(strings.ToLower(input.Model.ID), "[1m]") {
+		maxTokens = 1_000_000
+	}
 	maxTokensSource := maxTokensSourceModelInference
 	if envMax := os.Getenv("STATUSLINE_MAX_TOKENS"); envMax != "" {
 		v, err := strconv.Atoi(envMax)
@@ -514,19 +519,19 @@ func formatSegments(segments []statusline.Segment, maxWidth int, overflowMode st
 }
 
 // contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens）。
-// 依官方 Anthropic 規格：Sonnet/Opus major >= 5，或 major == 4 且 minor >= 6 時為 1M；其餘為 200K。
+// 依官方 Anthropic 規格：Sonnet/Opus/Fable major >= 5，或 major == 4 且 minor >= 6 時為 1M；其餘為 200K。
 // 此函式永遠是百分比的分母（denominator）；ContextWindowSize 不可用作分母（見 hasContextWindow 上方注解）。
 func contextWindowForModel(modelID string) int {
 	id := strings.ToLower(modelID)
+	// "[1m]" 是 Claude Code 對 1M context session 的明確標記（如 claude-fable-5[1m]），
+	// 比家族/版本推斷更可靠，優先採信。
+	if strings.Contains(id, "[1m]") {
+		return 1_000_000
+	}
 	switch {
 	case strings.Contains(id, "haiku"):
 		return 200_000 // Haiku 從未超過 200K；如有更大版本請重新評估
-	case strings.Contains(id, "sonnet"):
-		if claudeModelIs1M(id) {
-			return 1_000_000
-		}
-		return 200_000
-	case strings.Contains(id, "opus"):
+	case strings.Contains(id, "sonnet"), strings.Contains(id, "opus"), strings.Contains(id, "fable"):
 		if claudeModelIs1M(id) {
 			return 1_000_000
 		}
@@ -551,7 +556,8 @@ func claudeModelIs1M(id string) bool {
 
 // claudeModelVersion 從 claude-*-{major}-{minor}[-date] 格式解析 (major, minor)。
 // 從 ID 末端向前掃描，找最後兩個連續的小整數 token（< 100，避免誤認 date suffix）。
-// 解析失敗時回傳 (-1, -1)。
+// 找不到兩個連續整數時，fallback 到最後一個單獨的小整數，視為 {major}.0
+// （如 claude-fable-5 → (5, 0)）。完全解析失敗時回傳 (-1, -1)。
 func claudeModelVersion(id string) (int, int) {
 	parts := strings.Split(id, "-")
 	for i := len(parts) - 1; i >= 1; i-- {
@@ -563,6 +569,13 @@ func claudeModelVersion(id string) (int, int) {
 		// 限制在合理版本範圍內（排除 date suffix 如 20250514）
 		if major > 0 && major < 100 && minor >= 0 && minor < 100 {
 			return major, minor
+		}
+	}
+	// 單版本號模型（無 minor）：取末端最後一個合理範圍的整數當 major
+	for i := len(parts) - 1; i >= 0; i-- {
+		major, err := strconv.Atoi(parts[i])
+		if err == nil && major > 0 && major < 100 {
+			return major, 0
 		}
 	}
 	return -1, -1

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -154,6 +154,42 @@ func TestContextTokensFromUsage(t *testing.T) {
 	}
 }
 
+// TestResolveMaxTokens 驗證分母決策鏈的三層優先順序：
+// model inference → input.Model.ID 的 [1m] 標記 → STATUSLINE_MAX_TOKENS env（無條件最終 override）。
+// regression anchor：transcript 推斷的 model 不帶 [1m] 後綴，只靠推斷會把 1M beta session 低估為 200K。
+func TestResolveMaxTokens(t *testing.T) {
+	cases := []struct {
+		name       string
+		effective  string
+		inputID    string
+		envMax     string
+		want       int
+		wantSource string
+	}{
+		// [1m] 標記覆蓋 transcript 推斷（核心 regression 情境）
+		{"input-1m-overrides-inference", "claude-sonnet-4-5", "claude-sonnet-4-5[1m]", "", 1_000_000, maxTokensSourceInput1MMarker},
+		{"input-1m-uppercase", "claude-sonnet-4-5", "claude-sonnet-4-5[1M]", "", 1_000_000, maxTokensSourceInput1MMarker},
+		// 無標記：走家族/版本推斷
+		{"plain-inference-200k", "claude-sonnet-4-5", "claude-sonnet-4-5", "", 200_000, maxTokensSourceModelInference},
+		{"plain-inference-fable-1m", "claude-fable-5", "", "", 1_000_000, maxTokensSourceModelInference},
+		// env var 無條件覆蓋 [1m] 標記（CLAUDE.md 文件化語意）
+		{"env-overrides-1m-marker", "claude-sonnet-4-5", "claude-sonnet-4-5[1m]", "300000", 300_000, maxTokensSourceEnvOverride},
+		{"env-overrides-inference", "claude-sonnet-4-6", "", "500000", 500_000, maxTokensSourceEnvOverride},
+		// 無效 env：退回前一層來源
+		{"invalid-env-keeps-1m-marker", "claude-sonnet-4-5", "claude-sonnet-4-5[1m]", "abc", 1_000_000, maxTokensSourceInput1MMarker},
+		{"non-positive-env-keeps-inference", "claude-sonnet-4-6", "claude-sonnet-4-6", "0", 1_000_000, maxTokensSourceModelInference},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, source := resolveMaxTokens(tc.effective, tc.inputID, tc.envMax)
+			if got != tc.want || source != tc.wantSource {
+				t.Errorf("resolveMaxTokens(%q, %q, %q) = (%d, %q), want (%d, %q)",
+					tc.effective, tc.inputID, tc.envMax, got, source, tc.want, tc.wantSource)
+			}
+		})
+	}
+}
+
 func TestClaudeModelVersion(t *testing.T) {
 	cases := []struct {
 		id        string
@@ -222,7 +258,9 @@ func TestContextWindowForModel(t *testing.T) {
 		// "[1m]" 標記：Claude Code 對 1M context session 的明確標記，優先於家族/版本推斷
 		{"fable-5-1m-marker", "claude-fable-5[1m]", 1_000_000},
 		{"sonnet-45-1m-marker", "claude-sonnet-4-5[1m]", 1_000_000},
-		// 未知非空模型：保守 fallback 200K
+		// 未知非空模型：版本規則仍適用（major >= 5 → 1M），其餘保守 fallback 200K
+		{"unknown-family-major5", "claude-nova-5", 1_000_000},
+		{"unknown-family-major4-minor6", "claude-nova-4-6", 1_000_000},
 		{"unknown-future", "claude-future-1", 200_000},
 		// 空字串：DefaultMaxTokens
 		{"empty-fallback", "", context.DefaultMaxTokens},

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -116,9 +116,9 @@ func TestContextWindowMaxTokens(t *testing.T) {
 // OutputTokens is explicitly excluded regardless of value.
 func TestContextTokensFromUsage(t *testing.T) {
 	cases := []struct {
-		name                 string
-		u                    statusline.ContextUsage
-		want                 int
+		name string
+		u    statusline.ContextUsage
+		want int
 	}{
 		{
 			name: "sums input and both cache fields",
@@ -166,12 +166,13 @@ func TestClaudeModelVersion(t *testing.T) {
 		{"claude-sonnet-5-0", 5, 0},
 		{"claude-opus-4-1-20250805", 4, 1},
 		{"claude-haiku-4-5", 4, 5},
-		// date-only format (no minor) → not parseable as valid version
-		{"claude-sonnet-4-20250514", -1, -1},
-		// trailing prefix, no digit
-		{"claude-sonnet-4-", -1, -1},
-		// unknown format
-		{"claude-future-1", -1, -1},
+		// 單版本號（無 minor）→ fallback 視為 {major}.0
+		{"claude-fable-5", 5, 0},
+		{"claude-sonnet-4-20250514", 4, 0},
+		{"claude-sonnet-4-", 4, 0},
+		{"claude-future-1", 1, 0},
+		// 完全無合理整數 → 不可解析
+		{"claude-sonnet-20250514", -1, -1},
 		{"", -1, -1},
 		{"sonnet-4-10", 4, 10},
 	}
@@ -214,6 +215,13 @@ func TestContextWindowForModel(t *testing.T) {
 		{"opus-45", "claude-opus-4-5", 200_000},
 		{"opus-45-dated", "claude-opus-4-5-20251101", 200_000},
 		{"opus-41", "claude-opus-4-1-20250805", 200_000},
+		// Fable 5+：major >= 5 → 1M（regression: 卡 100% 的根因，transcript model 為 claude-fable-5）
+		{"fable-5", "claude-fable-5", 1_000_000},
+		{"fable-5-dated", "claude-fable-5-20260101", 1_000_000},
+		{"fable-uppercase", "Claude-Fable-5", 1_000_000},
+		// "[1m]" 標記：Claude Code 對 1M context session 的明確標記，優先於家族/版本推斷
+		{"fable-5-1m-marker", "claude-fable-5[1m]", 1_000_000},
+		{"sonnet-45-1m-marker", "claude-sonnet-4-5[1m]", 1_000_000},
 		// 未知非空模型：保守 fallback 200K
 		{"unknown-future", "claude-future-1", 200_000},
 		// 空字串：DefaultMaxTokens

--- a/pkg/statusline/model.go
+++ b/pkg/statusline/model.go
@@ -41,8 +41,8 @@ type Input struct {
 		// This is NOT the model's maximum capacity (e.g. 1M for Sonnet 4.6).
 		// Use only to detect whether Claude Code provides CurrentUsage data (> 0 means yes).
 		// Never use as the percentage denominator; use contextWindowForModel() instead.
-		ContextWindowSize int `json:"context_window_size,omitempty"`
-		CurrentUsage ContextUsage `json:"current_usage,omitempty"`
+		ContextWindowSize int          `json:"context_window_size,omitempty"`
+		CurrentUsage      ContextUsage `json:"current_usage,omitempty"`
 		// UsedPercentage / RemainingPercentage：由 Claude Code 計算，僅供參考。
 		// 進度條使用 BuildFromTokens 自行計算，保持與 bar 渲染邏輯一致。
 		UsedPercentage      int `json:"used_percentage,omitempty"`


### PR DESCRIPTION
## Symptom

Context window percentage jumps to 100% early in a session and stays there, even though the session is nowhere near its limit. Example from a live Fable 5 session: `██████████ 100% 389k` on a 1M context window (actual usage ~39%).

## Root cause

`contextWindowForModel()` only recognized the haiku/sonnet/opus families. The new `fable` family (`claude-fable-5`) fell into the unknown-model 200K fallback, so the denominator was 200K while actual usage was 389k → 194%, clamped to 100% and stuck.

Two underlying defects plus one missing signal:

1. **Family allowlist misses `fable`** — `cmd/statusline/main.go:519` switch falls through to the 200K fallback (stderr was silently printing `unknown model "claude-fable-5"` the whole time).
2. **`claudeModelVersion()` requires a major-minor pair** — single-version IDs like `claude-fable-5` parsed as `(-1, -1)`, so even with the family added it would still resolve to 200K.
3. **`[1m]` marker ignored** — Claude Code marks 1M context sessions with a `[1m]` suffix on `model.id` (e.g. `claude-fable-5[1m]`); this explicit signal was never consulted.

## Fix

- `[1m]` in the model ID → return 1M immediately (most reliable signal, beats family/version inference).
- Add `fable` to the 1M-capable family case, sharing the existing `major >= 5` rule.
- `claudeModelVersion()` falls back to the last single small integer as `{major}.0` (`claude-fable-5` → `(5, 0)`).
- In `main()`, honor `input.Model.ID`'s `[1m]` marker over the transcript-inferred model — transcript `message.model` entries never carry the suffix, so inference alone underestimates the denominator for 1M-beta sessions of 200K-default models.
- gofmt alignment fix in `pkg/statusline/model.go` left over from #35.

## Verification

Reproduced deterministically with a real `claude-fable-5` transcript and `model.id = "claude-fable-5[1m]"`:

| Binary | Output |
|---|---|
| main HEAD (64962ee) | `unknown model "claude-fable-5", using 200K context window fallback` → **100% 389k** |
| this branch | **38% 389k** (389k/1M), no warning |

Regression tests added in `cmd/statusline/main_test.go`: `claude-fable-5`, `claude-fable-5[1m]`, `claude-sonnet-4-5[1m]`, single-version parsing cases. Full suite passes (`go test -count=1 ./...`), `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
