### PR TITLE
fix(terminal): Windows cross-compile (build-tag split for ioctl width)

### DIFF
--- a/pkg/terminal/detect.go
+++ b/pkg/terminal/detect.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
-	"unsafe"
 )
 
 // RenderMode 終端渲染模式
@@ -49,31 +47,17 @@ func Detect() RenderMode {
 	return ModeASCII
 }
 
-// winsize 是 TIOCGWINSZ ioctl 的回傳結構
-type winsize struct {
-	Row    uint16
-	Col    uint16
-	Xpixel uint16
-	Ypixel uint16
-}
-
 // Width 回傳終端的欄位寬度。
-// 優先用 ioctl TIOCGWINSZ，其次讀 COLUMNS 環境變數，最後預設 120。
+// 優先用平台原生查詢（Unix: ioctl TIOCGWINSZ；Windows: 不支援，直接 fallback），
+// 其次讀 COLUMNS 環境變數，最後預設 120。
+// 平台相關的 ioctl 實作見 width_unix.go / width_windows.go（以 build tag 分流，
+// 讓 GOOS=windows 交叉編譯不會碰到 Unix-only 的 syscall.SYS_IOCTL / TIOCGWINSZ）。
 func Width() int {
-	// 嘗試從 stdout/stderr/stdin 取得終端寬度
-	for _, fd := range []uintptr{1, 2, 0} {
-		var ws winsize
-		if _, _, errno := syscall.Syscall(
-			syscall.SYS_IOCTL,
-			fd,
-			syscall.TIOCGWINSZ,
-			uintptr(unsafe.Pointer(&ws)),
-		); errno == 0 && ws.Col > 0 {
-			return int(ws.Col)
-		}
+	if w, ok := terminalWidthFromIoctl(); ok {
+		return w
 	}
 
-	// Fallback: COLUMNS 環境變數
+	// Fallback: COLUMNS 環境變數（Claude Code 在 statusline context 下會設定此變數）
 	if cols := os.Getenv("COLUMNS"); cols != "" {
 		if n, err := strconv.Atoi(cols); err == nil && n > 0 {
 			return n

--- a/pkg/terminal/width_unix.go
+++ b/pkg/terminal/width_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// winsize 是 TIOCGWINSZ ioctl 的回傳結構
+type winsize struct {
+	Row    uint16
+	Col    uint16
+	Xpixel uint16
+	Ypixel uint16
+}
+
+// terminalWidthFromIoctl 嘗試從 stdout/stderr/stdin 透過 ioctl TIOCGWINSZ 取得終端欄位寬度。
+// 回傳 (width, true) 代表成功；(0, false) 代表無法取得（呼叫端會 fallback 到 COLUMNS）。
+func terminalWidthFromIoctl() (int, bool) {
+	for _, fd := range []uintptr{1, 2, 0} {
+		var ws winsize
+		if _, _, errno := syscall.Syscall(
+			syscall.SYS_IOCTL,
+			fd,
+			syscall.TIOCGWINSZ,
+			uintptr(unsafe.Pointer(&ws)),
+		); errno == 0 && ws.Col > 0 {
+			return int(ws.Col), true
+		}
+	}
+	return 0, false
+}

--- a/pkg/terminal/width_windows.go
+++ b/pkg/terminal/width_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package terminal
+
+// terminalWidthFromIoctl is a no-op on Windows: there is no TIOCGWINSZ ioctl, and the Unix-only
+// syscall.SYS_IOCTL / syscall.TIOCGWINSZ symbols do not exist there (cross-compiling with them
+// breaks the build). Return (0, false) so Width() falls back to the COLUMNS environment variable,
+// which Claude Code sets before running the status line command.
+func terminalWidthFromIoctl() (int, bool) {
+	return 0, false
+}


### PR DESCRIPTION
## What & why

Follow-up fix for the `v1.3.0` release. The tag-triggered `release.yml` cross-compiles `GOOS=windows`, but `pkg/terminal/detect.go` used `syscall.SYS_IOCTL` / `syscall.TIOCGWINSZ` unconditionally — Unix-only symbols that fail the Windows build (`undefined: syscall.SYS_IOCTL`).

This is a **pre-existing bug** that shipped untagged after `v1.2.0`; it first surfaced when the `v1.3.0` tag triggered the release build (no release tag had been pushed since the terminal-detection feature was added).

## Fix

Move the ioctl width query into `terminalWidthFromIoctl()` behind build tags:
- `width_unix.go` (`//go:build !windows`): the existing `TIOCGWINSZ` ioctl loop.
- `width_windows.go` (`//go:build windows`): returns `(0, false)` so `Width()` falls back to the `COLUMNS` env var (already the fallback today; Claude Code sets it in the status line context).

`Detect()` and the `COLUMNS`/default fallback are pure env-var logic and stay cross-platform in `detect.go`. No behavior change on Unix.

## Verification
- All five release targets cross-compile: `linux amd64/arm64`, `darwin amd64/arm64`, `windows amd64`.
- `make lint` clean; `go test ./...` all green.

After merge, the `v1.3.0` tag will be moved to the new merge commit to re-trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Zphteaxd7oeWYoNVSTPMm
