### PR TITLE
feat: support subagentStatusLine via --subagent flag (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Features
+
+- support Claude Code `subagentStatusLine` via a `--subagent` flag: renders per-subagent
+  agent-panel rows (name, status, per-agent context bar) from the distinct tasks payload (#47)
+- add reusable `pkg/modelwindow` (stdlib-only model→context-window inference with a
+  confidence signal) and `pkg/subagentstatus`; extract window logic out of `package main`
+- add `statusline.TruncateToWidth`, an ANSI-aware hard width clamp bounding each subagent
+  row to the payload's `columns`
+
+### Notes
+
+- verified via a real-payload spike that per-task `tokenCount` is current context occupancy
+  (not cumulative), so the per-agent percentage bar is safe; the two-part #35/#36 non-demoting
+  denominator guard is applied per task, and an untrusted denominator falls back to token-only
+
 ## [1.3.0] - 2026-06-18
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -180,6 +180,26 @@ Then manually add to your `~/.claude/settings.json`:
 }
 ```
 
+### Subagent status line (optional)
+
+The same binary can also render Claude Code's **subagent status line** — the per-agent
+rows shown in the agent panel below the prompt — via the `--subagent` flag. Point the
+binary directly at it (recommended over the wrapper, since the output is multi-line):
+
+```json
+{
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "~/.claude/omystatusline/bin/statusline-go --subagent"
+  }
+}
+```
+
+Each row shows the agent's name, status, and a context bar computed from its own model
+and token count. Requires Claude Code v2.1.205+ for per-agent model/context data; older
+versions fall back to a token-only row. This is opt-in and separate from the main
+`statusLine` — the installer does not configure it automatically.
+
 ### Manual Installation
 
 See [Installation Guide](docs/installation.md) for detailed instructions.
@@ -434,6 +454,25 @@ make install-simple
   }
 }
 ```
+
+### Subagent 狀態列（選用）
+
+同一支 binary 也能透過 `--subagent` 旗標渲染 Claude Code 的 **subagent 狀態列**——
+即 prompt 下方 agent panel 中每個 subagent 的那一列。因為輸出為多行，建議直接指向 binary
+（而非 wrapper）：
+
+```json
+{
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "~/.claude/omystatusline/bin/statusline-go --subagent"
+  }
+}
+```
+
+每一列顯示該 agent 的名稱、狀態，以及依其自身 model 與 token 數計算的 context 進度條。
+per-agent 的 model／context 資料需要 Claude Code v2.1.205+；較舊版本會退回只顯示 token 數。
+此功能為選用，與主 `statusLine` 獨立——安裝程式不會自動設定。
 
 ### 手動安裝
 

--- a/cmd/statusline/main.go
+++ b/cmd/statusline/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/howie/claude-code-omystatusline/pkg/context"
 	"github.com/howie/claude-code-omystatusline/pkg/git"
 	"github.com/howie/claude-code-omystatusline/pkg/gitstatus"
+	"github.com/howie/claude-code-omystatusline/pkg/modelwindow"
 	"github.com/howie/claude-code-omystatusline/pkg/session"
 	"github.com/howie/claude-code-omystatusline/pkg/speed"
 	"github.com/howie/claude-code-omystatusline/pkg/statusline"
@@ -34,13 +35,26 @@ const (
 	maxTokensSourceEnvOverride    = "env-override"
 )
 
-// context window 容量（官方 Anthropic 規格）。
+// context window 容量（官方 Anthropic 規格）。單一真實來源為 pkg/modelwindow，
+// 此處別名保留本地短名，供 resolveMaxTokens / contextWindowFromInput / 測試引用。
 const (
-	contextWindow1M   = 1_000_000
-	contextWindow200K = 200_000
+	contextWindow1M   = modelwindow.Window1M
+	contextWindow200K = modelwindow.Window200K
 )
 
 func main() {
+	// Resolve the run mode from argv BEFORE touching stdin: the main and subagent
+	// status lines take incompatible JSON schemas, so dispatch must precede decoding.
+	mode, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "statusline: %v\n", err)
+		os.Exit(2)
+	}
+	if mode == modeSubagent {
+		runSubagent()
+		return
+	}
+
 	var input statusline.Input
 	raw, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -580,74 +594,16 @@ func resolveMaxTokens(effectiveModelID, inputModelID, envMax string, inputWindow
 	return maxTokens, source
 }
 
-// contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens）。
-// ID 含 "[1m]" 標記時無條件回傳 1M（優先於下列家族/版本規則）。
-// 依官方 Anthropic 規格：Sonnet/Opus/Fable major >= 5，或 major == 4 且 minor >= 6 時為 1M；其餘為 200K。
-// 未知家族亦套用相同版本規則，避免下一個新家族重演 fable 落入 200K fallback 的 regression。
-// 此函式永遠是百分比的分母（denominator）；ContextWindowSize 不可用作分母（見 hasContextWindow 上方注解）。
+// contextWindowForModel 根據模型 ID 回傳 context window 大小（tokens），是主 statusline
+// 百分比的分母（denominator）。版本/家族推斷邏輯已抽到 pkg/modelwindow；此處僅保留主線
+// 特有的副作用：未知非空家族退回 200K 猜測時印一行 stderr 警告（modelwindow 本身無副作用）。
+// ContextWindowSize 不可用作分母（見 hasContextWindow 上方注解）。
 func contextWindowForModel(modelID string) int {
-	id := strings.ToLower(modelID)
-	// "[1m]" 是 Claude Code 對 1M context session 的明確標記（如 claude-fable-5[1m]），
-	// 比家族/版本推斷更可靠，優先採信。
-	if strings.Contains(id, "[1m]") {
-		return contextWindow1M
-	}
-	switch {
-	case strings.Contains(id, "haiku"):
-		return contextWindow200K // Haiku 從未超過 200K；如有更大版本請重新評估
-	case strings.Contains(id, "sonnet"), strings.Contains(id, "opus"), strings.Contains(id, "fable"):
-		if claudeModelIs1M(id) {
-			return contextWindow1M
-		}
-		return contextWindow200K
-	case id != "":
-		// 未知家族也套用版本規則：major >= 5 的新家族（如未來的 claude-nova-5）
-		// 視為 1M，不再無條件 200K。
-		if claudeModelIs1M(id) {
-			return contextWindow1M
-		}
+	size, confident := modelwindow.Infer(modelID)
+	if !confident && modelID != "" {
 		fmt.Fprintf(os.Stderr, "statusline: unknown model %q, using 200K context window fallback\n", modelID)
-		return contextWindow200K
-	default:
-		return context.DefaultMaxTokens
 	}
-}
-
-// claudeModelIs1M 回報 claude 模型是否有 1M context window。
-// 解析 claude-*-{major}-{minor}[-date] 中的 major/minor，版本規則：
-//   - major >= 5 → 1M（為未來大版本預留）
-//   - major == 4 && minor >= 6 → 1M（Sonnet 4.6+、Opus 4.6+）
-//   - 其他 → false（保守 fallback）
-func claudeModelIs1M(id string) bool {
-	major, minor := claudeModelVersion(id)
-	return major >= 5 || (major == 4 && minor >= 6)
-}
-
-// claudeModelVersion 從 claude-*-{major}-{minor}[-date] 格式解析 (major, minor)。
-// 從 ID 末端向前掃描，找最後兩個連續的小整數 token（< 100，避免誤認 date suffix）。
-// 找不到兩個連續整數時，fallback 到最後一個單獨的小整數，視為 {major}.0
-// （如 claude-fable-5 → (5, 0)）。完全解析失敗時回傳 (-1, -1)。
-func claudeModelVersion(id string) (int, int) {
-	parts := strings.Split(id, "-")
-	for i := len(parts) - 1; i >= 1; i-- {
-		minor, err1 := strconv.Atoi(parts[i])
-		major, err2 := strconv.Atoi(parts[i-1])
-		if err1 != nil || err2 != nil {
-			continue
-		}
-		// 限制在合理版本範圍內（排除 date suffix 如 20250514）
-		if major > 0 && major < 100 && minor >= 0 && minor < 100 {
-			return major, minor
-		}
-	}
-	// 單版本號模型（無 minor）：取末端最後一個合理範圍的整數當 major
-	for i := len(parts) - 1; i >= 0; i-- {
-		major, err := strconv.Atoi(parts[i])
-		if err == nil && major > 0 && major < 100 {
-			return major, 0
-		}
-	}
-	return -1, -1
+	return size
 }
 
 // contextWindowFromInput trusts Claude Code's reported context_window_size as the percentage

--- a/cmd/statusline/main_test.go
+++ b/cmd/statusline/main_test.go
@@ -283,38 +283,8 @@ func TestResolveMaxTokens(t *testing.T) {
 	}
 }
 
-func TestClaudeModelVersion(t *testing.T) {
-	cases := []struct {
-		id        string
-		wantMajor int
-		wantMinor int
-	}{
-		{"claude-sonnet-4-6", 4, 6},
-		{"claude-opus-4-7-20251001", 4, 7},
-		{"claude-sonnet-4-5-20250929", 4, 5},
-		{"claude-sonnet-5-0", 5, 0},
-		{"claude-opus-4-1-20250805", 4, 1},
-		{"claude-haiku-4-5", 4, 5},
-		// 單版本號（無 minor）→ fallback 視為 {major}.0
-		{"claude-fable-5", 5, 0},
-		{"claude-sonnet-4-20250514", 4, 0},
-		{"claude-sonnet-4-", 4, 0},
-		{"claude-future-1", 1, 0},
-		// 完全無合理整數 → 不可解析
-		{"claude-sonnet-20250514", -1, -1},
-		{"", -1, -1},
-		{"sonnet-4-10", 4, 10},
-	}
-	for _, tc := range cases {
-		t.Run(tc.id, func(t *testing.T) {
-			maj, min := claudeModelVersion(strings.ToLower(tc.id))
-			if maj != tc.wantMajor || min != tc.wantMinor {
-				t.Errorf("claudeModelVersion(%q) = (%d, %d), want (%d, %d)", tc.id, maj, min, tc.wantMajor, tc.wantMinor)
-			}
-		})
-	}
-}
-
+// Version parsing moved to pkg/modelwindow (see TestVersion there). TestContextWindowForModel
+// below stays as the byte-for-byte characterization test of the main-line wrapper.
 func TestContextWindowForModel(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/cmd/statusline/subagent.go
+++ b/cmd/statusline/subagent.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/howie/claude-code-omystatusline/pkg/context"
+	"github.com/howie/claude-code-omystatusline/pkg/subagentstatus"
+	"github.com/howie/claude-code-omystatusline/pkg/terminal"
+)
+
+// runMode selects which status line the binary renders. The mode is chosen from argv
+// BEFORE stdin is read or decoded, because the two modes take incompatible JSON schemas.
+type runMode int
+
+const (
+	modeMain runMode = iota
+	modeSubagent
+)
+
+// parseArgs resolves the run mode from CLI arguments. Only the "--subagent" flag is
+// recognized; anything else (unknown flag or stray positional) is an error so a
+// misconfigured command fails loudly instead of silently rendering the wrong schema.
+func parseArgs(args []string) (runMode, error) {
+	mode := modeMain
+	for _, a := range args {
+		switch a {
+		case "--subagent":
+			mode = modeSubagent
+		default:
+			return modeMain, fmt.Errorf("unexpected argument %q", a)
+		}
+	}
+	return mode, nil
+}
+
+// renderSubagentJSON decodes a subagentStatusLine payload and renders its rows. It is
+// the pure, testable core of the subagent path: no stdin, no os.Exit. An empty/absent
+// tasks list yields "" (zero bytes). A flat main-line payload decodes with no tasks and
+// so also yields "" — fail-safe rather than garbage.
+func renderSubagentJSON(raw []byte) (string, error) {
+	var in subagentstatus.Input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return "", err
+	}
+	return subagentstatus.Render(in), nil
+}
+
+// runSubagent is the I/O wrapper around renderSubagentJSON for the --subagent path.
+func runSubagent() {
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "statusline: failed to read subagent input: %v\n", err)
+		os.Exit(1)
+	}
+	// Same inert capture hook as the main path (owner-only; may contain task text).
+	if dumpPath := os.Getenv("STATUSLINE_DUMP_INPUT"); dumpPath != "" {
+		if werr := os.WriteFile(dumpPath, raw, 0o600); werr != nil {
+			fmt.Fprintf(os.Stderr, "statusline: STATUSLINE_DUMP_INPUT write to %q failed: %v\n", dumpPath, werr)
+		}
+	}
+	context.RenderMode = terminal.Detect()
+	out, err := renderSubagentJSON(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "statusline: failed to decode subagent input: %v\n", err)
+		os.Exit(1)
+	}
+	if out != "" {
+		fmt.Println(out)
+	}
+}

--- a/cmd/statusline/subagent_test.go
+++ b/cmd/statusline/subagent_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/howie/claude-code-omystatusline/pkg/context"
+	"github.com/howie/claude-code-omystatusline/pkg/terminal"
+)
+
+func TestParseArgs(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantMode runMode
+		wantErr  bool
+	}{
+		{"no-args-main", nil, modeMain, false},
+		{"subagent-flag", []string{"--subagent"}, modeSubagent, false},
+		{"unknown-flag", []string{"--bogus"}, modeMain, true},
+		{"unexpected-positional", []string{"--subagent", "extra"}, modeMain, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, err := parseArgs(tc.args)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseArgs(%v) err = %v, wantErr %v", tc.args, err, tc.wantErr)
+			}
+			if err == nil && mode != tc.wantMode {
+				t.Errorf("parseArgs(%v) mode = %v, want %v", tc.args, mode, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestRenderSubagentJSON(t *testing.T) {
+	context.RenderMode = terminal.ModeASCII
+
+	t.Run("multi-task", func(t *testing.T) {
+		raw := []byte(`{"columns":80,"tasks":[
+			{"name":"first","status":"running","model":"claude-haiku-4-5","tokenCount":1000},
+			{"name":"second","status":"completed","model":"claude-haiku-4-5","tokenCount":2000}]}`)
+		out, err := renderSubagentJSON(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Count(out, "\n") != 1 {
+			t.Errorf("expected 2 lines, got %q", out)
+		}
+	})
+
+	t.Run("empty-tasks-zero-bytes", func(t *testing.T) {
+		out, err := renderSubagentJSON([]byte(`{"columns":80,"tasks":[]}`))
+		if err != nil || out != "" {
+			t.Errorf("expected zero bytes, got (%q, %v)", out, err)
+		}
+	})
+
+	t.Run("malformed-json-errors", func(t *testing.T) {
+		if _, err := renderSubagentJSON([]byte(`{bad`)); err == nil {
+			t.Error("expected error for malformed JSON")
+		}
+	})
+
+	t.Run("main-schema-is-safe", func(t *testing.T) {
+		// Feeding the flat main-line payload to the subagent path must not error or
+		// render garbage — no tasks -> zero bytes.
+		raw := []byte(`{"model":{"id":"claude-opus-4-8"},"workspace":{"current_dir":"/x"}}`)
+		out, err := renderSubagentJSON(raw)
+		if err != nil || out != "" {
+			t.Errorf("main-schema should be safe, got (%q, %v)", out, err)
+		}
+	})
+}

--- a/pkg/modelwindow/modelwindow.go
+++ b/pkg/modelwindow/modelwindow.go
@@ -1,0 +1,95 @@
+// Package modelwindow maps a Claude model ID to its context window size.
+//
+// It is deliberately dependency-free (standard library only) and side-effect-free
+// (no logging, no globals) so it can be shared by both the main status line and the
+// per-subagent status line without one caller's policy or stderr noise leaking into
+// the other. Callers layer their own precedence and warnings on top of Infer.
+package modelwindow
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Context window capacities (official Anthropic specs).
+const (
+	Window200K = 200_000
+	Window1M   = 1_000_000
+)
+
+// Infer reports a model's context window size and whether that size was determined
+// with confidence.
+//
+// confident is false in exactly two cases: an empty modelID, or an unrecognized
+// non-versioned family that only reaches the fail-safe 200K guess. Callers that must
+// never render a falsely-inflated percentage from a guessed denominator (the
+// per-subagent bar) should treat !confident as "no trusted denominator" and fall
+// back to a token-only display. The main status line ignores confident and always
+// uses size, preserving its historical fail-safe behavior.
+//
+// Rules (an explicit "[1m]" marker wins over family/version inference):
+//   - "[1m]" in the ID              -> 1M, confident
+//   - Haiku                         -> 200K, confident
+//   - Sonnet/Opus/Fable            -> 1M if major>=5 or 4.6+, else 200K; confident
+//   - Unknown family, version>=1M  -> 1M, confident
+//   - Unknown family, guessed      -> 200K, NOT confident
+//   - Empty                         -> 200K, NOT confident
+func Infer(modelID string) (size int, confident bool) {
+	id := strings.ToLower(modelID)
+	if id == "" {
+		return Window200K, false
+	}
+	if strings.Contains(id, "[1m]") {
+		return Window1M, true
+	}
+	switch {
+	case strings.Contains(id, "haiku"):
+		return Window200K, true
+	case strings.Contains(id, "sonnet"), strings.Contains(id, "opus"), strings.Contains(id, "fable"):
+		if is1M(id) {
+			return Window1M, true
+		}
+		return Window200K, true
+	default:
+		// Unknown non-empty family: apply the version rule so the next new family
+		// (e.g. claude-nova-5) is treated as 1M instead of silently capped at 200K.
+		// A version-resolved 1M is confident; a bare 200K guess is not.
+		if is1M(id) {
+			return Window1M, true
+		}
+		return Window200K, false
+	}
+}
+
+// is1M reports whether a lowercased model ID has a 1M context window by version:
+// major>=5, or major==4 && minor>=6.
+func is1M(id string) bool {
+	major, minor := version(id)
+	return major >= 5 || (major == 4 && minor >= 6)
+}
+
+// version parses (major, minor) from a claude-*-{major}-{minor}[-date] ID.
+// It scans from the end for the last two consecutive small integers (< 100, to skip
+// date suffixes like 20250514). Failing that, it falls back to the last standalone
+// small integer as {major}.0 (e.g. claude-fable-5 -> (5, 0)). Returns (-1, -1) when
+// nothing parseable is found. The input is expected to already be lowercased.
+func version(id string) (int, int) {
+	parts := strings.Split(id, "-")
+	for i := len(parts) - 1; i >= 1; i-- {
+		minor, err1 := strconv.Atoi(parts[i])
+		major, err2 := strconv.Atoi(parts[i-1])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		if major > 0 && major < 100 && minor >= 0 && minor < 100 {
+			return major, minor
+		}
+	}
+	for i := len(parts) - 1; i >= 0; i-- {
+		major, err := strconv.Atoi(parts[i])
+		if err == nil && major > 0 && major < 100 {
+			return major, 0
+		}
+	}
+	return -1, -1
+}

--- a/pkg/modelwindow/modelwindow_test.go
+++ b/pkg/modelwindow/modelwindow_test.go
@@ -1,0 +1,78 @@
+package modelwindow
+
+import "testing"
+
+func TestInfer(t *testing.T) {
+	cases := []struct {
+		name          string
+		modelID       string
+		wantSize      int
+		wantConfident bool
+	}{
+		// Empty: fail-safe fallback, NOT confident (callers must not draw a % from a guess).
+		{"empty", "", Window200K, false},
+		// Explicit [1m] marker wins over everything, confident.
+		{"opus-1m-marker", "claude-opus-4-8[1m]", Window1M, true},
+		{"sonnet-1m-marker-uppercase", "claude-sonnet-4-5[1M]", Window1M, true},
+		// Haiku is always 200K, confident.
+		{"haiku", "claude-haiku-4-5", Window200K, true},
+		{"haiku-dated", "claude-haiku-4-5-20251001", Window200K, true},
+		// Known families by version, confident either way.
+		{"sonnet-46-1m", "claude-sonnet-4-6", Window1M, true},
+		{"sonnet-45-200k", "claude-sonnet-4-5", Window200K, true},
+		{"opus-48-1m", "claude-opus-4-8", Window1M, true},
+		{"opus-45-200k", "claude-opus-4-5", Window200K, true},
+		{"fable-5-1m", "claude-fable-5", Window1M, true},
+		{"sonnet-5-default-1m", "claude-sonnet-5", Window1M, true},
+		// Known family with unparseable version defaults to 200K but stays confident
+		// (a sonnet/opus/fable id is still a recognized family).
+		{"sonnet-unparseable-version", "claude-sonnet-20250514", Window200K, true},
+		// Unknown family resolved by version rule (major>=5 or 4.6+): confident 1M.
+		{"unknown-family-major5", "claude-mythos-5", Window1M, true},
+		{"unknown-family-4-6", "claude-nova-4-6", Window1M, true},
+		// Unknown family that only reaches the 200K guess: NOT confident.
+		{"unknown-family-guess-200k", "claude-future-1", Window200K, false},
+		{"unknown-family-no-version", "totally-unknown", Window200K, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, confident := Infer(tc.modelID)
+			if size != tc.wantSize || confident != tc.wantConfident {
+				t.Errorf("Infer(%q) = (%d, %v), want (%d, %v)",
+					tc.modelID, size, confident, tc.wantSize, tc.wantConfident)
+			}
+		})
+	}
+}
+
+func TestVersion(t *testing.T) {
+	cases := []struct {
+		id        string
+		wantMajor int
+		wantMinor int
+	}{
+		{"claude-sonnet-4-6", 4, 6},
+		{"claude-opus-4-7-20251001", 4, 7},
+		{"claude-sonnet-4-5-20250929", 4, 5},
+		{"claude-sonnet-5-0", 5, 0},
+		{"claude-opus-4-1-20250805", 4, 1},
+		{"claude-haiku-4-5", 4, 5},
+		// Single version number (no minor) falls back to {major}.0.
+		{"claude-fable-5", 5, 0},
+		{"claude-sonnet-4-20250514", 4, 0},
+		{"claude-sonnet-4-", 4, 0},
+		{"claude-future-1", 1, 0},
+		// No parseable integer at all.
+		{"claude-sonnet-20250514", -1, -1},
+		{"", -1, -1},
+		{"sonnet-4-10", 4, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			maj, min := version(tc.id)
+			if maj != tc.wantMajor || min != tc.wantMinor {
+				t.Errorf("version(%q) = (%d, %d), want (%d, %d)", tc.id, maj, min, tc.wantMajor, tc.wantMinor)
+			}
+		})
+	}
+}

--- a/pkg/statusline/truncate_width.go
+++ b/pkg/statusline/truncate_width.go
@@ -1,0 +1,78 @@
+package statusline
+
+import "strings"
+
+// TruncateToWidth hard-clamps s to at most maxWidth visible cells. Unlike TruncateLine
+// (which protects high-priority segments and can exceed the requested width), this is a
+// guaranteed upper bound: VisibleWidth(result) <= maxWidth always.
+//
+// It is ANSI-aware — CSI color sequences and OSC 8 hyperlinks contribute 0 width and are
+// copied through — and never splits a wide (width-2) rune. If the cut lands inside colored
+// text, a trailing ColorReset is appended so color does not bleed past the row. maxWidth
+// <= 0 returns "".
+//
+// Used by the subagent status line to bound each row to the payload's `columns`, which
+// TruncateLine cannot guarantee.
+func TruncateToWidth(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if VisibleWidth(s) <= maxWidth {
+		return s
+	}
+
+	var b strings.Builder
+	width := 0
+	sawEscape := false
+	inEscape := false // CSI (\033[...)
+	inOSC := false    // OSC (\033]...)
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if inOSC {
+			b.WriteRune(r)
+			if r == '\a' {
+				inOSC = false
+			} else if r == '\033' && i+1 < len(runes) && runes[i+1] == '\\' {
+				b.WriteRune(runes[i+1])
+				i++
+				inOSC = false
+			}
+			continue
+		}
+		if inEscape {
+			b.WriteRune(r)
+			if r >= 0x40 && r <= 0x7E {
+				inEscape = false
+			}
+			continue
+		}
+		if r == '\033' && i+1 < len(runes) && runes[i+1] == '[' {
+			b.WriteRune(r)
+			b.WriteRune(runes[i+1])
+			i++
+			inEscape = true
+			sawEscape = true
+			continue
+		}
+		if r == '\033' && i+1 < len(runes) && runes[i+1] == ']' {
+			b.WriteRune(r)
+			b.WriteRune(runes[i+1])
+			i++
+			inOSC = true
+			sawEscape = true
+			continue
+		}
+		w := runeWidth(r)
+		if width+w > maxWidth {
+			break
+		}
+		b.WriteRune(r)
+		width += w
+	}
+
+	if sawEscape {
+		b.WriteString(ColorReset)
+	}
+	return b.String()
+}

--- a/pkg/statusline/truncate_width_test.go
+++ b/pkg/statusline/truncate_width_test.go
@@ -1,0 +1,65 @@
+package statusline
+
+import "testing"
+
+func TestTruncateToWidth(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		maxWidth int
+		want     string
+	}{
+		{"fits", "abc", 5, "abc"},
+		{"exact", "abc", 3, "abc"},
+		{"truncate-ascii", "abcdef", 3, "abc"},
+		{"zero-width", "abc", 0, ""},
+		{"negative-width", "abc", -1, ""},
+		{"empty-input", "", 5, ""},
+		// Wide char must not be split: あ is width 2.
+		{"wide-fits", "aあ", 3, "aあ"},
+		{"wide-would-overflow", "aあb", 2, "a"},
+		{"wide-first-too-big", "あ", 1, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TruncateToWidth(tc.in, tc.maxWidth)
+			if got != tc.want {
+				t.Errorf("TruncateToWidth(%q, %d) = %q, want %q", tc.in, tc.maxWidth, got, tc.want)
+			}
+			if VisibleWidth(got) > tc.maxWidth && tc.maxWidth > 0 {
+				t.Errorf("TruncateToWidth(%q, %d) = %q has visible width %d > %d",
+					tc.in, tc.maxWidth, got, VisibleWidth(got), tc.maxWidth)
+			}
+		})
+	}
+}
+
+// ANSI color sequences contribute 0 width and must survive truncation, with a
+// trailing reset appended so a cut inside colored text does not bleed.
+func TestTruncateToWidthPreservesANSI(t *testing.T) {
+	in := "\033[31mabcdef\033[0m"
+	got := TruncateToWidth(in, 3)
+	if VisibleWidth(got) != 3 {
+		t.Errorf("visible width = %d, want 3 (got %q)", VisibleWidth(got), got)
+	}
+	if !containsRune(got, '\033') {
+		t.Errorf("expected color escape preserved, got %q", got)
+	}
+	// Must end with a reset to avoid color bleed after a mid-color cut.
+	if !hasSuffix(got, ColorReset) {
+		t.Errorf("expected trailing reset %q, got %q", ColorReset, got)
+	}
+}
+
+func containsRune(s string, r rune) bool {
+	for _, c := range s {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/pkg/subagentstatus/model.go
+++ b/pkg/subagentstatus/model.go
@@ -1,0 +1,37 @@
+// Package subagentstatus renders Claude Code's subagentStatusLine payload: the
+// per-subagent rows shown in the agent panel below the prompt. Its input schema is
+// distinct from the main statusline's flat single-session object — it carries all
+// visible subagent rows in one JSON object per refresh tick.
+package subagentstatus
+
+// Input mirrors the subagentStatusLine stdin payload. Only the fields this renderer
+// needs are modeled; encoding/json ignores the rest (real payloads also carry
+// agent_type, cwd, prompt_id, session_id, transcript_path at the top level).
+type Input struct {
+	// Columns is the usable row width Claude Code allots each rendered row.
+	Columns int    `json:"columns,omitempty"`
+	Tasks   []Task `json:"tasks,omitempty"`
+}
+
+// Task is one subagent row. Per-task model/contextWindowSize require Claude Code
+// v2.1.205+ and are omitted for a task whose model isn't resolved yet, so every
+// field is treated as optional. tokenSamples/startTime/cwd are not needed for the
+// v1 row. effort is intentionally NOT modeled: it was absent from every captured
+// payload and its exact JSON type is unverified — adding it blind risks a decode error.
+type Task struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Status      string `json:"status,omitempty"`
+	// Model is the resolved model ID; real payloads carry the "[1m]" suffix
+	// (e.g. "claude-opus-4-8[1m]"), which modelwindow.Infer handles.
+	Model string `json:"model,omitempty"`
+	// ContextWindowSize is Claude Code's reported per-task window. Trusted as a
+	// percentage denominator only via resolveWindow's two-part guard.
+	ContextWindowSize int `json:"contextWindowSize,omitempty"`
+	// TokenCount is the subagent's CURRENT context occupancy (verified via spike:
+	// gauge, not cumulative), so it is a valid numerator for the context bar.
+	TokenCount int `json:"tokenCount,omitempty"`
+}

--- a/pkg/subagentstatus/render.go
+++ b/pkg/subagentstatus/render.go
@@ -1,0 +1,119 @@
+package subagentstatus
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/howie/claude-code-omystatusline/pkg/context"
+	"github.com/howie/claude-code-omystatusline/pkg/statusline"
+	"github.com/howie/claude-code-omystatusline/pkg/terminal"
+)
+
+// Render produces the subagentStatusLine output: one line per task, in input order,
+// each hard-clamped to in.Columns visible cells. Returns "" (zero bytes) when there
+// are no tasks, so an idle agent panel stays truly empty. Rendering mode (ASCII vs
+// color) follows context.RenderMode, which the caller sets from terminal.Detect().
+func Render(in Input) string {
+	if len(in.Tasks) == 0 {
+		return ""
+	}
+	ascii := context.RenderMode == terminal.ModeASCII
+	rows := make([]string, 0, len(in.Tasks))
+	for i := range in.Tasks {
+		rows = append(rows, renderRow(in.Tasks[i], in.Columns, ascii))
+	}
+	return strings.Join(rows, "\n")
+}
+
+// renderRow builds one clamped row for a single task.
+func renderRow(t Task, columns int, ascii bool) string {
+	body := statusGlyph(t.Status, ascii) + " " + taskName(t)
+
+	if denom, ok := resolveWindow(t.Model, t.ContextWindowSize); ok {
+		// tokenCount is current context occupancy (verified via spike), a valid
+		// numerator. BuildFromTokens clamps the percentage to 0-100, so a tokenCount
+		// above the window shows 100% while keeping the raw count.
+		cd := context.BuildFromTokens(t.TokenCount, denom)
+		body += cd.Bar + cd.Info
+	} else {
+		// No trusted denominator: token-only, never a guessed percentage. Do NOT call
+		// BuildFromTokens(_, 0) here — it would fall back to 200K and manufacture a %.
+		body += " (" + formatTokens(t.TokenCount) + ")"
+	}
+
+	// columns<=0 means Claude Code gave no width budget: render the full row rather
+	// than emitting nothing (TruncateToWidth(_, 0) == "").
+	if columns <= 0 {
+		return body
+	}
+	return statusline.TruncateToWidth(body, columns)
+}
+
+// taskName picks the best display label: name -> label -> type -> shortened id -> "task".
+// Real payloads often omit name and carry the text in label. Control characters are
+// stripped so injected \n/\r cannot break the one-row-per-task contract.
+func taskName(t Task) string {
+	for _, cand := range []string{t.Name, t.Label, t.Type} {
+		if s := sanitize(cand); s != "" {
+			return s
+		}
+	}
+	if id := sanitize(t.ID); id != "" {
+		if len(id) > 8 {
+			id = id[:8]
+		}
+		return id
+	}
+	return "task"
+}
+
+// sanitize strips C0/C1 control characters (including \n, \r, \t, ESC) and trims spaces,
+// so task-provided text cannot inject newlines, move the cursor, or smuggle ANSI codes.
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r < 0x20 || (r >= 0x7F && r < 0xA0) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// statusGlyph maps a task status to a compact indicator, ASCII-safe when needed.
+func statusGlyph(status string, ascii bool) string {
+	if ascii {
+		switch status {
+		case "running":
+			return ">"
+		case "completed":
+			return "+"
+		case "failed", "error":
+			return "x"
+		case "pending", "queued":
+			return "."
+		default:
+			return "*"
+		}
+	}
+	switch status {
+	case "running":
+		return "▸"
+	case "completed":
+		return "●"
+	case "failed", "error":
+		return "✗"
+	case "pending", "queued":
+		return "◦"
+	default:
+		return "•"
+	}
+}
+
+// formatTokens renders a compact token count for token-only rows (e.g. 12345 -> "12k").
+func formatTokens(n int) string {
+	if n < 1000 {
+		return fmt.Sprintf("%d", n)
+	}
+	return fmt.Sprintf("%dk", n/1000)
+}

--- a/pkg/subagentstatus/render_test.go
+++ b/pkg/subagentstatus/render_test.go
@@ -1,0 +1,147 @@
+package subagentstatus
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/howie/claude-code-omystatusline/pkg/context"
+	"github.com/howie/claude-code-omystatusline/pkg/statusline"
+	"github.com/howie/claude-code-omystatusline/pkg/terminal"
+)
+
+func init() {
+	// Deterministic, color-free output for golden-style assertions.
+	context.RenderMode = terminal.ModeASCII
+}
+
+func TestRenderFullRow(t *testing.T) {
+	in := Input{
+		Columns: 80,
+		Tasks: []Task{{
+			Name:              "verifier",
+			Status:            "completed",
+			Model:             "claude-opus-4-8[1m]",
+			ContextWindowSize: 1_000_000,
+			TokenCount:        159195,
+		}},
+	}
+	got := Render(in)
+	if strings.Count(got, "\n") != 0 {
+		t.Fatalf("single task should be one line, got %q", got)
+	}
+	if !strings.Contains(got, "verifier") {
+		t.Errorf("row missing name: %q", got)
+	}
+	if !strings.Contains(got, "15%") {
+		t.Errorf("row missing percentage 15%%: %q", got)
+	}
+	if !strings.Contains(got, "159k") {
+		t.Errorf("row missing token count 159k: %q", got)
+	}
+	if statusline.VisibleWidth(got) > 80 {
+		t.Errorf("row width %d > 80: %q", statusline.VisibleWidth(got), got)
+	}
+}
+
+func TestRenderTokenOnlyWhenNoDenominator(t *testing.T) {
+	in := Input{
+		Columns: 80,
+		Tasks: []Task{{
+			Name:       "scout",
+			Status:     "running",
+			Model:      "totally-unknown",
+			TokenCount: 12345,
+		}},
+	}
+	got := Render(in)
+	if !strings.Contains(got, "scout") {
+		t.Errorf("row missing name: %q", got)
+	}
+	if strings.Contains(got, "%") {
+		t.Errorf("token-only row must not show a percentage: %q", got)
+	}
+	if !strings.Contains(got, "12k") {
+		t.Errorf("row missing token count 12k: %q", got)
+	}
+}
+
+func TestRenderNameFallback(t *testing.T) {
+	in := Input{
+		Columns: 80,
+		Tasks: []Task{{
+			// no Name, no Label -> falls back to Type.
+			Type:       "local_agent",
+			Status:     "running",
+			Model:      "claude-haiku-4-5",
+			TokenCount: 1000,
+		}},
+	}
+	got := Render(in)
+	if !strings.Contains(got, "local_agent") {
+		t.Errorf("expected type fallback, got %q", got)
+	}
+}
+
+func TestRenderEmptyTasksIsZeroBytes(t *testing.T) {
+	if got := Render(Input{Columns: 80}); got != "" {
+		t.Errorf("empty tasks must render zero bytes, got %q", got)
+	}
+	if got := Render(Input{Columns: 80, Tasks: []Task{}}); got != "" {
+		t.Errorf("empty task slice must render zero bytes, got %q", got)
+	}
+}
+
+func TestRenderNarrowColumnsHardBound(t *testing.T) {
+	in := Input{
+		Columns: 8,
+		Tasks: []Task{{
+			Name:              "a-very-long-subagent-name-that-overflows",
+			Status:            "running",
+			Model:             "claude-opus-4-8[1m]",
+			ContextWindowSize: 1_000_000,
+			TokenCount:        500000,
+		}},
+	}
+	got := Render(in)
+	if statusline.VisibleWidth(got) > 8 {
+		t.Errorf("row width %d > 8: %q", statusline.VisibleWidth(got), got)
+	}
+}
+
+func TestRenderMultiTaskOrderPreserved(t *testing.T) {
+	in := Input{
+		Columns: 80,
+		Tasks: []Task{
+			{Name: "first", Status: "running", Model: "claude-haiku-4-5", TokenCount: 1000},
+			{Name: "second", Status: "completed", Model: "claude-haiku-4-5", TokenCount: 2000},
+		},
+	}
+	got := Render(in)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), got)
+	}
+	if !strings.Contains(lines[0], "first") || !strings.Contains(lines[1], "second") {
+		t.Errorf("task order not preserved: %q", got)
+	}
+}
+
+func TestRenderSanitizesControlChars(t *testing.T) {
+	in := Input{
+		Columns: 80,
+		Tasks: []Task{{
+			Name:       "evil\nname\r2",
+			Status:     "running",
+			Model:      "claude-haiku-4-5",
+			TokenCount: 1000,
+		}},
+	}
+	got := Render(in)
+	if strings.ContainsAny(got, "\r") {
+		t.Errorf("carriage return leaked into output: %q", got)
+	}
+	// One task must stay one line: injected \n must not create a second row.
+	if strings.Count(got, "\n") != 0 {
+		t.Errorf("injected newline created extra line(s): %q", got)
+	}
+}

--- a/pkg/subagentstatus/window.go
+++ b/pkg/subagentstatus/window.go
@@ -1,0 +1,33 @@
+package subagentstatus
+
+import "github.com/howie/claude-code-omystatusline/pkg/modelwindow"
+
+// resolveWindow decides the percentage denominator for one task, applying the same
+// two-part guard that protects the main statusline from the #35/#36 "stuck at 100%"
+// bug: a reported size is trusted only when it is a KNOWN capacity (200K/1M) AND it
+// does not demote a confident inference.
+//
+// Returns (denominator, true) when a percentage may be drawn, or (0, false) when the
+// caller must fall back to a token-only display (no guessed denominator — a wrong
+// guess of 200K would make a real 1M subagent look full, the exact bug we avoid).
+func resolveWindow(model string, reported int) (denominator int, ok bool) {
+	inferred, confident := modelwindow.Infer(model)
+	if isKnownCapacity(reported) {
+		// Non-demotion: a confident inference is never lowered by a smaller reported
+		// value (e.g. inferred 1M, reported 200K -> keep 1M).
+		if confident && inferred > reported {
+			return inferred, true
+		}
+		return reported, true
+	}
+	// Reported is absent or not a recognized capacity: use inference only if confident,
+	// otherwise token-only.
+	if confident {
+		return inferred, true
+	}
+	return 0, false
+}
+
+func isKnownCapacity(n int) bool {
+	return n == modelwindow.Window200K || n == modelwindow.Window1M
+}

--- a/pkg/subagentstatus/window_test.go
+++ b/pkg/subagentstatus/window_test.go
@@ -1,0 +1,50 @@
+package subagentstatus
+
+import (
+	"testing"
+
+	"github.com/howie/claude-code-omystatusline/pkg/modelwindow"
+)
+
+// TestResolveWindow covers the Q3 matrix: the two-part #35/#36 guard applied per task.
+// A denominator is trusted only when it is a known capacity AND does not demote a
+// confident inference; otherwise fall back to confident inference; otherwise token-only.
+func TestResolveWindow(t *testing.T) {
+	cases := []struct {
+		name     string
+		model    string
+		reported int
+		wantSize int
+		wantOK   bool
+	}{
+		// known model, size omitted -> inferred.
+		{"known-model-no-size", "claude-opus-4-8[1m]", 0, modelwindow.Window1M, true},
+		{"known-200k-model-no-size", "claude-haiku-4-5", 0, modelwindow.Window200K, true},
+		// model omitted, reported known capacity -> trust reported.
+		{"no-model-reported-1m", "", modelwindow.Window1M, modelwindow.Window1M, true},
+		{"no-model-reported-200k", "", modelwindow.Window200K, modelwindow.Window200K, true},
+		// NON-DEMOTION (the core #35/#36 guard): confident 1M, reported 200K -> keep 1M.
+		{"non-demoting-keeps-1m", "claude-opus-4-8[1m]", modelwindow.Window200K, modelwindow.Window1M, true},
+		// reported >= inferred is honored (rescue an under-estimate).
+		{"reported-rescues-to-1m", "claude-sonnet-4-5", modelwindow.Window1M, modelwindow.Window1M, true},
+		// unknown model, non-capacity reported -> token-only (no guessed denominator).
+		{"unknown-model-junk-size", "totally-unknown", 500000, 0, false},
+		{"unknown-model-no-size", "totally-unknown", 0, 0, false},
+		// both omitted -> token-only.
+		{"both-omitted", "", 0, 0, false},
+		// negative reported never used as a denominator.
+		{"negative-reported-known-model", "claude-haiku-4-5", -5, modelwindow.Window200K, true},
+		{"negative-reported-unknown-model", "totally-unknown", -5, 0, false},
+		// unknown model but reported IS a known capacity -> trust the allow-set value.
+		{"unknown-model-reported-200k", "totally-unknown", modelwindow.Window200K, modelwindow.Window200K, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, ok := resolveWindow(tc.model, tc.reported)
+			if size != tc.wantSize || ok != tc.wantOK {
+				t.Errorf("resolveWindow(%q, %d) = (%d, %v), want (%d, %v)",
+					tc.model, tc.reported, size, ok, tc.wantSize, tc.wantOK)
+			}
+		})
+	}
+}

--- a/scripts/statusline-wrapper.sh
+++ b/scripts/statusline-wrapper.sh
@@ -9,12 +9,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Execute the Go statusline binary with JSON input and use printf to interpret ANSI codes
 # Set STATUSLINE_DUMP_STDIN=/tmp/statusline-stdin.json to capture the raw stdin for debugging.
 # Reads stdin once into a variable so the dump and the binary receive the same data.
+# "$@" forwards CLI args (e.g. --subagent) so this wrapper can back subagentStatusLine too.
+# Note: for the multi-line subagentStatusLine output, pointing subagentStatusLine directly
+# at statusline-go (bypassing this wrapper's printf %b) is recommended; see README.
 if [ -n "$STATUSLINE_DUMP_STDIN" ]; then
   stdin_data=$(cat)
   if ! printf '%s\n' "$stdin_data" > "$STATUSLINE_DUMP_STDIN"; then
     printf 'statusline-wrapper: WARNING: could not write STATUSLINE_DUMP_STDIN to %s\n' "$STATUSLINE_DUMP_STDIN" >&2
   fi
-  printf "%b" "$(printf '%s\n' "$stdin_data" | "$SCRIPT_DIR/statusline-go")"
+  printf "%b" "$(printf '%s\n' "$stdin_data" | "$SCRIPT_DIR/statusline-go" "$@")"
 else
-  printf "%b" "$(cat | "$SCRIPT_DIR/statusline-go")"
+  printf "%b" "$(cat | "$SCRIPT_DIR/statusline-go" "$@")"
 fi


### PR DESCRIPTION
Implements #47 — support Claude Code's `subagentStatusLine` (the per-agent rows in the agent panel below the prompt).

## What & why

The subagent payload is a different schema from the main `statusLine` (a `{columns, tasks:[...]}` object, not the flat single-session object), so the existing binary could not render it. This adds a `--subagent` mode that renders one clamped row per task.

Design was reviewed adversarially with OpenAI Codex and de-risked with a real-payload spike (both recorded on #47). The spike confirmed per-task `tokenCount` is **current context occupancy** (a gauge, not cumulative), so the per-agent percentage bar is safe.

## Changes

- **`pkg/modelwindow`** (new, stdlib-only): model→context-window inference with a confidence signal, extracted from `package main`. The main line keeps `contextWindowForModel` as a thin wrapper; `TestContextWindowForModel` is the byte-for-byte characterization guard.
- **`pkg/subagentstatus`** (new): `Input`/`Task` DTOs (ignore unknown fields), a per-task denominator resolver applying the **two-part #35/#36 non-demoting guard** (trust a reported size only when it is a known capacity AND not below a confident inference; otherwise confident inference; otherwise **token-only, never a guessed %**), and a row renderer (name→label→type→id fallback, status glyph, control-char sanitization).
- **`statusline.TruncateToWidth`** (new): ANSI-aware hard width clamp bounding each row to the payload's `columns` — `TruncateLine` is not a hard bound.
- **`cmd/statusline`**: `--subagent` dispatch parsed **before** stdin decode; unknown args fail loudly. `statusline-wrapper.sh` now forwards `"$@"`.
- **Docs**: README (EN + 繁中) opt-in config; CHANGELOG `[Unreleased]`.

## Codex's three 🔴 findings, all addressed

1. Non-demotion is applied per task (not just the allow-set) — `resolveWindow`.
2. Wrapper now forwards `"$@"`; README recommends pointing `subagentStatusLine` directly at the binary for multi-line output.
3. `TruncateToWidth` is the hard clamp; `TruncateLine` was not one.

Plus the spike resolved the `tokenCount` semantics gate before any percentage code was written.

## Tests

TDD throughout (red→green per unit). New coverage: `modelwindow.Infer`/`version`, the Q3 denominator matrix, renderer (full row, token-only, name fallback, empty→zero bytes, narrow-columns hard bound, multi-task order, control-char sanitization), `TruncateToWidth` (incl. ANSI + wide chars), and `--subagent` dispatch (unknown flag, malformed JSON, main-schema safety).

`go test ./...`, `gofmt -s`, `go vet`, and `make lint` (golangci-lint: 0 issues) all green. Verified end-to-end against a captured real payload.

## Deferred (per plan)

Installer auto-wiring of `subagentStatusLine` and an `effort` field (absent from every captured payload; JSON type unverified) are intentionally out of scope for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcgPc2UgZynQ2kCr2hx3wY
